### PR TITLE
shadcn/#33

### DIFF
--- a/app/utils/shadcn/utils.ts
+++ b/app/utils/shadcn/utils.ts
@@ -1,0 +1,6 @@
+import { twMerge } from 'tailwind-merge';
+import { type ClassValue, clsx } from 'clsx';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/components.json
+++ b/components.json
@@ -7,11 +7,12 @@
     "config": "tailwind.config.ts",
     "css": "app/globals.css",
     "baseColor": "slate",
-    "cssVariables": true,
+    "cssVariables": false,
     "prefix": ""
   },
   "aliases": {
     "components": "@/app/ui/view/shadcn",
+    "ui": "@/app/ui/view/shadcn",
     "utils": "@/app/utils/shadcn/utils"
   }
 }

--- a/components.json
+++ b/components.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/app/ui/view/shadcn",
+    "utils": "@/app/utils/shadcn/utils"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,12 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "express": "^4.18.2",
+        "lucide-react": "^0.336.0",
         "next": "14.1.0",
         "react": "^18",
         "react-dom": "^18",
-        "tailwind-merge": "^2.2.1"
+        "tailwind-merge": "^2.2.1",
+        "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "^7.6.15",
@@ -15155,6 +15157,14 @@
         "node": "14 || >=16.14"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.336.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.336.0.tgz",
+      "integrity": "sha512-e06J4Qrdrk3BP/hf3MnkW3LnymdthfyEtVbdEg0xPQ/olTEKfOfTv03DYmdRm1+XpaNQdCpiHT7Vi6regbxDCQ==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -19364,6 +19374,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "express": "^4.18.2",
+    "lucide-react": "^0.336.0",
     "next": "14.1.0",
     "react": "^18",
     "react-dom": "^18",
-    "tailwind-merge": "^2.2.1"
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.6.15",
@@ -40,7 +42,6 @@
     "@storybook/nextjs": "^7.6.15",
     "@storybook/react": "^7.6.15",
     "@storybook/test": "^7.6.15",
-    "chromatic": "^10.9.4",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",
@@ -50,6 +51,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
+    "chromatic": "^10.9.4",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
     "eslint": "^8",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,6 +45,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [headlessui],
+  plugins: [headlessui, require('tailwindcss-animate')],
 };
 export default config;


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x] shadcn 기본 설정
- cli를 통한 설치를 위해 `component.json`설정을 진행
  - utils파일은  `@/app/utils/shadcn/utils` 경로로 지정
  - cli를 통해 설치하는 경우 UI구성 요소의 생성 위치를 `@/app/ui/view/shadcn` 경로로 지정
       -  실제 저희 폴더 구조에 영향을 미치진 않겠지만, 개발 편의를 위해서 view폴더의 하위로 위치를 지정했습니다.




## 🤔 고민 했던 부분
- headless ui의 사용이 필요할 때마다 [cli로 설치](https://ui.shadcn.com/docs/components/alert-dialog)하여 사용할 수 있습니다. 
- shadcn/ui 프로젝트를 설정할때 자동으로 생성되는 `tailwind.config.json`및  `global.css`의 변경은, 자체적 component를 개발하자고 했던 우리 팀의 목적과 맞지 않는 것 같아 반영하지않았습니다.
- 기존의 @headlessui/tailwindcss 와 관련있는 코드가 존재하므로, 제거하지 않았습니다.

