### PR TITLE
button size 조정

### DIFF
--- a/app/(sub-page)/layout.tsx
+++ b/app/(sub-page)/layout.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import background from '../../public/assets/background.png';
-import NavigationBar from '../ui/view/molecule/navigation-bar';
+
 interface LayoutProps {
   children: React.ReactNode;
 }

--- a/app/ui/view/atom/button/button.stories.tsx
+++ b/app/ui/view/atom/button/button.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import Button from './button';
 

--- a/app/ui/view/atom/button/button.tsx
+++ b/app/ui/view/atom/button/button.tsx
@@ -25,7 +25,7 @@ export const ButtonVariants = cva(`flex justify-center items-center`, {
       default: '',
       xs: 'px-5 py-2.5 text-sm font-medium leading-5',
       sm: 'px-10 py-2.5 text-xs font-medium leading-3',
-      md: 'px-20 py-4 text-md font-medium leading-3',
+      md: 'px-20 py-4 text-base font-medium leading-3',
       lg: 'px-28 py-4 text-2xl font-medium leading-9',
     },
   },

--- a/app/ui/view/atom/button/button.tsx
+++ b/app/ui/view/atom/button/button.tsx
@@ -23,10 +23,10 @@ export const ButtonVariants = cva(`flex justify-center items-center`, {
     },
     size: {
       default: '',
-      xs: 'px-5 py-3 text-lg font-medium leading-5',
-      sm: 'px-12 py-3.5 text-sm font-medium leading-3',
-      md: 'px-6 py-4 text-lg font-medium leading-3',
-      lg: 'px-32 py-6 text-3xl font-medium leading-9',
+      xs: 'px-5 py-2.5 text-sm font-medium leading-5',
+      sm: 'px-10 py-2.5 text-xs font-medium leading-3',
+      md: 'px-20 py-4 text-md font-medium leading-3',
+      lg: 'px-28 py-4 text-2xl font-medium leading-9',
     },
   },
 });

--- a/app/ui/view/molecule/form/form-submit-button.tsx
+++ b/app/ui/view/molecule/form/form-submit-button.tsx
@@ -15,7 +15,7 @@ export function FormSubmitButton({
   label,
   position = 'right',
   variant = 'primary',
-  size = 'sm',
+  size = 'md',
 }: FormSubmitButtonProps) {
   const { formId } = useContext(FormContext);
   const { pending } = useFormStatus();


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x] 버튼 사이즈 리사이징

## 🤔 고민 했던 부분
- button size의 기준은 [기존 프로젝트](https://mju-graduate.com/)의 1500px과 figma가 동일한 것을 확인하고, 해당 기준에 맞춰서 진행했습니다.
- 버튼 사이즈 내의 반응형은 기존의 논의대로 고려하지 않았습니다.
- 사이즈는 기존의 lg, md, sm, xs을 기준으로 변경을 진행했으며, 대표적으로 쓰임이 되는 예시를 사진으로 첨부합니다.
  - lg
   <img width="773" alt="스크린샷 2024-03-27 오후 7 20 00" src="https://github.com/Myongji-Graduate/myongji-graduate-next/assets/75975946/e0433ea9-a90e-4a60-a5b0-030ee5c3eb88">
- md
   <img width="816" alt="스크린샷 2024-03-27 오후 7 22 22" src="https://github.com/Myongji-Graduate/myongji-graduate-next/assets/75975946/06e9e24f-7d08-408c-b090-779a81f968d4">
- sm
  <img width="216" alt="스크린샷 2024-03-27 오후 7 22 53" src="https://github.com/Myongji-Graduate/myongji-graduate-next/assets/75975946/e2de0e16-7a17-47d7-8738-229ab71ecdfb">
- xs
   <img width="610" alt="스크린샷 2024-03-27 오후 7 23 17" src="https://github.com/Myongji-Graduate/myongji-graduate-next/assets/75975946/b07c2241-c639-4260-b4c1-ea657e7e5219">

