### PR TITLE
Auth/#62

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,6 +21,7 @@ const config: StorybookConfig = {
         ...config.resolve.alias,
         '@': path.resolve(__dirname, '../'),
         'next/headers': path.resolve(__dirname, '../app/utils/test/__mock__/next/headers.ts'),
+        'next/navigation': path.resolve(__dirname, '../app/utils/test/__mock__/next/navigation.ts'),
       };
     }
     return config;

--- a/app/business/user/user.command.ts
+++ b/app/business/user/user.command.ts
@@ -2,7 +2,7 @@
 
 import { FormState } from '@/app/ui/view/molecule/form/form-root';
 import { API_PATH } from '../api-path';
-import { SignUpRequestBody, SignInRequestBody } from './user.type';
+import { SignUpRequestBody, SignInRequestBody, ValidateTokenResponse } from './user.type';
 import { httpErrorHandler } from '@/app/utils/http/http-error-handler';
 import { BadRequestError } from '@/app/utils/http/http-error';
 import {
@@ -15,7 +15,7 @@ import { cookies } from 'next/headers';
 import { isValidation } from '@/app/utils/zod/validation.util';
 import { redirect } from 'next/navigation';
 
-export async function validateToken() {
+export async function validateToken(): Promise<ValidateTokenResponse | boolean> {
   const accessToken = cookies().get('accessToken')?.value;
   const refreshToken = cookies().get('refreshToken')?.value;
   try {

--- a/app/business/user/user.command.ts
+++ b/app/business/user/user.command.ts
@@ -13,6 +13,7 @@ import {
 } from './user.validation';
 import { cookies } from 'next/headers';
 import { isValidation } from '@/app/utils/zod/validation.util';
+import { redirect } from 'next/navigation';
 
 export async function validateToken() {
   const accessToken = cookies().get('accessToken')?.value;
@@ -88,6 +89,8 @@ export async function authenticate(prevState: FormState, formData: FormData): Pr
         secure: process.env.NODE_ENV === 'production',
         path: '/',
       });
+
+      redirect('/my');
     }
   } catch (error) {
     if (error instanceof BadRequestError) {

--- a/app/business/user/user.query.ts
+++ b/app/business/user/user.query.ts
@@ -1,0 +1,30 @@
+import { httpErrorHandler } from '@/app/utils/http/http-error-handler';
+import { API_PATH } from '../api-path';
+import { UserInfoResponse } from './user.type';
+import { cookies } from 'next/headers';
+import { isValidation } from '@/app/utils/zod/validation.util';
+import { UserInfoResponseSchema } from './user.validation';
+
+export async function getUserInfo(): Promise<UserInfoResponse> {
+  // 유저 정보 요청
+  try {
+    const response = await fetch(`${API_PATH.user}`, {
+      headers: {
+        Authorization: `Bearer ${cookies().get('accessToken')?.value}`,
+      },
+    });
+
+    const result = await response.json();
+
+    httpErrorHandler(response, result);
+
+    if (isValidation(result, UserInfoResponseSchema)) {
+      return result;
+    } else {
+      throw 'Invalid user info response schema.';
+    }
+    return result;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/app/business/user/user.query.ts
+++ b/app/business/user/user.query.ts
@@ -23,7 +23,6 @@ export async function getUserInfo(): Promise<UserInfoResponse> {
     } else {
       throw 'Invalid user info response schema.';
     }
-    return result;
   } catch (error) {
     throw error;
   }

--- a/app/business/user/user.query.ts
+++ b/app/business/user/user.query.ts
@@ -6,7 +6,6 @@ import { isValidation } from '@/app/utils/zod/validation.util';
 import { UserInfoResponseSchema } from './user.validation';
 
 export async function getUserInfo(): Promise<UserInfoResponse> {
-  // 유저 정보 요청
   try {
     const response = await fetch(`${API_PATH.user}`, {
       headers: {

--- a/app/business/user/user.type.ts
+++ b/app/business/user/user.type.ts
@@ -1,7 +1,7 @@
 // https://stackoverflow.com/questions/76957592/error-only-async-functions-are-allowed-to-be-exported-in-a-use-server-file
 // server action 파일에서는 async function만 export 가능
 
-import { SignInResponseSchema, UserInfoResponseSchema } from './user.validation';
+import { SignInResponseSchema, UserInfoResponseSchema, ValidateTokenResponseSchema } from './user.validation';
 import z from 'zod';
 
 export interface SignUpRequestBody {
@@ -19,3 +19,5 @@ export interface SignInRequestBody {
 export type SignInResponse = z.infer<typeof SignInResponseSchema>;
 
 export type UserInfoResponse = z.infer<typeof UserInfoResponseSchema>;
+
+export type ValidateTokenResponse = z.infer<typeof ValidateTokenResponseSchema>;

--- a/app/business/user/user.type.ts
+++ b/app/business/user/user.type.ts
@@ -1,7 +1,7 @@
 // https://stackoverflow.com/questions/76957592/error-only-async-functions-are-allowed-to-be-exported-in-a-use-server-file
 // server action 파일에서는 async function만 export 가능
 
-import { SignInResponseSchema } from './user.validation';
+import { SignInResponseSchema, UserInfoResponseSchema } from './user.validation';
 import z from 'zod';
 
 export interface SignUpRequestBody {
@@ -17,3 +17,5 @@ export interface SignInRequestBody {
 }
 
 export type SignInResponse = z.infer<typeof SignInResponseSchema>;
+
+export type UserInfoResponse = z.infer<typeof UserInfoResponseSchema>;

--- a/app/business/user/user.validation.ts
+++ b/app/business/user/user.validation.ts
@@ -1,5 +1,13 @@
 import { z } from 'zod';
 
+// api 변경 예정
+export const UserInfoResponseSchema = z.object({
+  studentNumber: z.string(),
+  studentName: z.string(),
+  major: z.string(),
+  isSumbitted: z.boolean(),
+});
+
 export const ValidateTokenResponseSchema = z.object({
   accessToken: z.string(),
 });

--- a/app/business/user/user.validation.ts
+++ b/app/business/user/user.validation.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+export const ValidateTokenResponseSchema = z.object({
+  accessToken: z.string(),
+});
+
 export const SignInFormSchema = z.object({
   authId: z.string(),
   password: z.string(),

--- a/app/mocks/db.mock.ts
+++ b/app/mocks/db.mock.ts
@@ -1,5 +1,5 @@
 import { TakenLectures } from '../business/lecture/taken-lecture.query';
-import { SignUpRequestBody, SignInRequestBody } from '../business/user/user.type';
+import { SignUpRequestBody, SignInRequestBody, UserInfoResponse } from '../business/user/user.type';
 import { takenLectures } from './data.mock';
 
 interface MockUser {
@@ -7,7 +7,9 @@ interface MockUser {
   password: string;
   studentNumber: string;
   engLv: string;
-  major?: string;
+  major: string;
+  isSumbitted: boolean;
+  name: string;
 }
 
 interface MockDatabaseState {
@@ -18,8 +20,9 @@ interface MockDatabaseState {
 type MockDatabaseAction = {
   getTakenLectures: () => TakenLectures[];
   getUser: (authId: string) => MockUser | undefined;
-  createUser: (user: MockUser) => boolean;
+  createUser: (user: SignUpRequestBody) => boolean;
   signIn: (userData: SignInRequestBody) => boolean;
+  getUserInfo: (authId: string) => UserInfoResponse;
 };
 
 export const mockDatabase: MockDatabaseAction = {
@@ -29,12 +32,37 @@ export const mockDatabase: MockDatabaseAction = {
     if (mockDatabaseStore.users.find((u) => u.authId === user.authId || u.studentNumber === user.studentNumber)) {
       return false;
     }
-    mockDatabaseStore.users = [...mockDatabaseStore.users, user];
+    mockDatabaseStore.users = [
+      ...mockDatabaseStore.users,
+      {
+        ...user,
+        isSumbitted: false,
+        major: '융소입니다',
+        name: '모킹이2',
+      },
+    ];
     return true;
   },
   signIn: (userData: SignInRequestBody) => {
     const user = mockDatabaseStore.users.find((u) => u.authId === userData.authId && u.password === userData.password);
     return !!user;
+  },
+  getUserInfo: (authId: string) => {
+    const user = mockDatabaseStore.users.find((u) => u.authId === authId);
+    if (!user) {
+      return {
+        studentNumber: '',
+        studentName: '',
+        major: '',
+        isSumbitted: false,
+      };
+    }
+    return {
+      studentNumber: user.studentNumber,
+      studentName: user.name,
+      major: user.major,
+      isSumbitted: user.isSumbitted,
+    };
   },
 };
 
@@ -46,6 +74,9 @@ const initialState: MockDatabaseState = {
       password: 'admin',
       studentNumber: '60000000',
       engLv: 'ENG12',
+      isSumbitted: false,
+      major: '융소입니다',
+      name: '모킹이',
     },
   ],
 };

--- a/app/mocks/handlers/user-handler.mock.ts
+++ b/app/mocks/handlers/user-handler.mock.ts
@@ -1,10 +1,35 @@
 import { HttpResponse, http, delay } from 'msw';
 import { API_PATH } from '../../business/api-path';
 import { mockDatabase } from '../db.mock';
-import { SignUpRequestBody, SignInRequestBody, SignInResponse } from '@/app/business/user/user.type';
+import {
+  SignUpRequestBody,
+  SignInRequestBody,
+  SignInResponse,
+  ValidateTokenResponse,
+} from '@/app/business/user/user.type';
 import { ErrorResponseData } from '@/app/utils/http/http-error-handler';
 
 export const userHandlers = [
+  http.post<never, never, ValidateTokenResponse>(`${API_PATH.auth}/token`, async ({ request }) => {
+    return HttpResponse.json({
+      accessToken: 'fake-access-token',
+    });
+  }),
+  // http.get<never, never>(`${API_PATH.user}`, async ({ cookies  }) => {
+  //   const accessToken = headers.get('Authorization')?.replace('Bearer ', '');
+  //   if (!accessToken) {
+  //     return HttpResponse.json({ status: 401, message: 'Unauthorized' }, { status: 401 });
+  //   }
+
+  //   const userInfo = mockDatabase.getUserInfo(accessToken);
+  //   await delay(500);
+
+  //   if (!userInfo) {
+  //     return HttpResponse.json({ status: 401, message: 'Unauthorized' }, { status: 401 });
+  //   }
+
+  //   return HttpResponse.json(userInfo);
+  // }
   http.post<never, SignUpRequestBody, never>(`${API_PATH.user}/sign-up`, async ({ request }) => {
     const userData = await request.json();
 
@@ -17,7 +42,6 @@ export const userHandlers = [
 
     return HttpResponse.json({ status: 200 });
   }),
-
   http.post<never, SignInRequestBody, SignInResponse | ErrorResponseData>(
     `${API_PATH.auth}/sign-in`,
     async ({ request }) => {

--- a/app/mocks/handlers/user-handler.mock.ts
+++ b/app/mocks/handlers/user-handler.mock.ts
@@ -6,8 +6,20 @@ import {
   SignInRequestBody,
   SignInResponse,
   ValidateTokenResponse,
+  UserInfoResponse,
 } from '@/app/business/user/user.type';
 import { ErrorResponseData } from '@/app/utils/http/http-error-handler';
+
+function mockDecryptToken(token: string) {
+  if (token === 'fake-access-token') {
+    return {
+      authId: 'admin',
+    };
+  }
+  return {
+    authId: '',
+  };
+}
 
 export const userHandlers = [
   http.post<never, never, ValidateTokenResponse>(`${API_PATH.auth}/token`, async ({ request }) => {
@@ -15,21 +27,21 @@ export const userHandlers = [
       accessToken: 'fake-access-token',
     });
   }),
-  // http.get<never, never>(`${API_PATH.user}`, async ({ cookies  }) => {
-  //   const accessToken = headers.get('Authorization')?.replace('Bearer ', '');
-  //   if (!accessToken) {
-  //     return HttpResponse.json({ status: 401, message: 'Unauthorized' }, { status: 401 });
-  //   }
+  http.get<never, never, UserInfoResponse | ErrorResponseData>(`${API_PATH.user}`, async ({ request }) => {
+    const accessToken = request.headers.get('Authorization')?.replace('Bearer ', '');
+    if (!accessToken) {
+      return HttpResponse.json({ status: 401, message: 'Unauthorized' }, { status: 401 });
+    }
 
-  //   const userInfo = mockDatabase.getUserInfo(accessToken);
-  //   await delay(500);
+    const userInfo = mockDatabase.getUserInfo(mockDecryptToken(accessToken).authId);
+    await delay(500);
 
-  //   if (!userInfo) {
-  //     return HttpResponse.json({ status: 401, message: 'Unauthorized' }, { status: 401 });
-  //   }
+    if (!userInfo) {
+      return HttpResponse.json({ status: 401, message: 'Unauthorized' }, { status: 401 });
+    }
 
-  //   return HttpResponse.json(userInfo);
-  // }
+    return HttpResponse.json(userInfo);
+  }),
   http.post<never, SignUpRequestBody, never>(`${API_PATH.user}/sign-up`, async ({ request }) => {
     const userData = await request.json();
 

--- a/app/ui/user/sign-in-form/sign-in-form.stories.tsx
+++ b/app/ui/user/sign-in-form/sign-in-form.stories.tsx
@@ -27,9 +27,6 @@ const meta = {
       );
     },
   ],
-  args: {
-    onNext: fn(),
-  },
 } as Meta<typeof SignInForm>;
 
 export default meta;
@@ -37,19 +34,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-const beforeEach = () => {
-  resetMockDB();
-  mockDatabase.createUser({
-    authId: 'testtest',
-    password: 'test1234!',
-    studentNumber: '60000001',
-    engLv: 'ENG12',
-  });
-};
-
 export const SuccessSenario: Story = {
-  play: async ({ args, canvasElement, step }) => {
-    beforeEach();
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
     await step('사용자가 양식에 맞춰서 폼을 입력하면', async () => {
@@ -60,14 +46,13 @@ export const SuccessSenario: Story = {
     });
 
     await step('로그인에 성공한다', async () => {
-      await waitFor(() => expect(args.onNext).toHaveBeenCalled());
+      await waitFor(() => expect(canvas.queryByText('아이디 또는 비밀번호가 일치하지 않습니다.')).toBeNull());
     });
   },
 };
 
 export const FailureScenarioWithoutUser: Story = {
-  play: async ({ args, canvasElement, step }) => {
-    beforeEach();
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
     await step('사용자가 존재하지 않는 아이디로 로그인하면', async () => {
@@ -78,7 +63,6 @@ export const FailureScenarioWithoutUser: Story = {
     });
 
     await step('로그인에 실패한다', async () => {
-      await waitFor(() => expect(args.onNext).not.toHaveBeenCalled());
       expect(await canvas.findByText('아이디 또는 비밀번호가 일치하지 않습니다.')).toBeInTheDocument();
     });
   },

--- a/app/ui/user/sign-in-form/sign-in-form.tsx
+++ b/app/ui/user/sign-in-form/sign-in-form.tsx
@@ -2,13 +2,9 @@
 import Form from '../../view/molecule/form';
 import { authenticate } from '@/app/business/user/user.command';
 
-interface SignInFormProps {
-  onNext?: () => void;
-}
-
-export default function SignInForm({ onNext }: SignInFormProps) {
+export default function SignInForm() {
   return (
-    <Form onSuccess={onNext} id="로그인" action={authenticate}>
+    <Form id="로그인" action={authenticate}>
       <Form.TextInput required={true} label="아이디" id="authId" placeholder="아이디를 입력하세요" />
       <Form.PasswordInput required={true} label="비밀번호" id="password" placeholder="비밀번호를 입력하세요" />
       <Form.SubmitButton label="로그인" position="center" variant="primary" />

--- a/app/utils/test/__mock__/next/navigation.ts
+++ b/app/utils/test/__mock__/next/navigation.ts
@@ -1,0 +1,1 @@
+export function redirect() {}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,8 @@
 import type { NextRequest } from 'next/server';
-import { API_PATH } from './app/business/api-path';
 import { validateToken } from './app/business/user/user.command';
 import { getUserInfo } from './app/business/user/user.query';
-import { UserInfoResponse } from './app/business/user/user.type';
 
 async function getAuth(request: NextRequest): Promise<{
-  user?: UserInfoResponse;
   role: 'guest' | 'user' | 'init';
 }> {
   const accessToken = request.cookies.get('accessToken')?.value;
@@ -30,9 +27,6 @@ async function getAuth(request: NextRequest): Promise<{
   // 유저 정보 요청
   const user = await getUserInfo();
   return {
-    user: {
-      ...user,
-    },
     role: user.isSumbitted ? 'user' : 'init',
   };
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,18 @@
-async function getAuth(request: NextRequest): Promise<UserInfoResponse | boolean> {
+import type { NextRequest } from 'next/server';
+import { API_PATH } from './app/business/api-path';
+import { validateToken } from './app/business/user/user.command';
+import { getUserInfo } from './app/business/user/user.query';
+import { UserInfoResponse } from './app/business/user/user.type';
+
+async function getAuth(request: NextRequest): Promise<{
+  user?: UserInfoResponse;
+  role: 'guest' | 'user' | 'init';
+}> {
   const accessToken = request.cookies.get('accessToken')?.value;
   if (!accessToken) {
-    return false;
+    return {
+      role: 'guest',
+    };
   }
 
   const validatedResult = await validateToken();
@@ -9,16 +20,41 @@ async function getAuth(request: NextRequest): Promise<UserInfoResponse | boolean
   if (!validatedResult) {
     request.cookies.delete('accessToken');
     request.cookies.delete('refreshToken');
-    return false;
+    return {
+      role: 'guest',
+    };
   }
 
   request.cookies.set('accessToken', validatedResult.accessToken);
 
   // 유저 정보 요청
-  try {
-    const user = await getUserInfo();
-    return user;
-  } catch {
-    return false;
+  const user = await getUserInfo();
+  return {
+    user: {
+      ...user,
+    },
+    role: user.isSumbitted ? 'user' : 'init',
+  };
+}
+
+const allowdGuestPath = ['/tutorial', '/sign-in', '/sign-up', '/find-password', '/find-id'];
+
+function isAllowedGuestPath(path: string) {
+  return allowdGuestPath.some((allowedPath) => path.startsWith(allowedPath));
+}
+
+export async function middleware(request: NextRequest) {
+  const auth = await getAuth(request);
+
+  if (auth.role === 'guest' && !isAllowedGuestPath(request.nextUrl.pathname)) {
+    return Response.redirect(new URL('/sign-in', request.url));
+  }
+
+  if (auth.role === 'init') {
+    return Response.redirect(new URL('/grade-upload', request.url));
   }
 }
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|.*\\.png$).*)'],
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -46,12 +46,12 @@ function isAllowedGuestPath(path: string) {
 export async function middleware(request: NextRequest) {
   const auth = await getAuth(request);
 
-  if (auth.role === 'guest' && !isAllowedGuestPath(request.nextUrl.pathname)) {
-    return Response.redirect(new URL('/sign-in', request.url));
+  if (auth.role === 'init' && !request.nextUrl.pathname.startsWith('/grade-upload')) {
+    return Response.redirect(new URL('/grade-upload', request.url));
   }
 
-  if (auth.role === 'init') {
-    return Response.redirect(new URL('/grade-upload', request.url));
+  if (auth.role === 'guest' && !isAllowedGuestPath(request.nextUrl.pathname)) {
+    return Response.redirect(new URL('/sign-in', request.url));
   }
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,24 @@
+async function getAuth(request: NextRequest): Promise<UserInfoResponse | boolean> {
+  const accessToken = request.cookies.get('accessToken')?.value;
+  if (!accessToken) {
+    return false;
+  }
+
+  const validatedResult = await validateToken();
+
+  if (!validatedResult) {
+    request.cookies.delete('accessToken');
+    request.cookies.delete('refreshToken');
+    return false;
+  }
+
+  request.cookies.set('accessToken', validatedResult.accessToken);
+
+  // 유저 정보 요청
+  try {
+    const user = await getUserInfo();
+    return user;
+  } catch {
+    return false;
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,14 +38,19 @@ function isAllowedGuestPath(path: string) {
 }
 
 export async function middleware(request: NextRequest) {
-  const auth = await getAuth(request);
+  const isAuth = request.nextUrl.searchParams.get('isAuth');
 
-  if (auth.role === 'init' && !request.nextUrl.pathname.startsWith('/grade-upload')) {
-    return Response.redirect(new URL('/grade-upload', request.url));
-  }
+  // 개발용이성을 위해 isAuth=true 일 때만 동작
+  if (isAuth === 'true') {
+    const auth = await getAuth(request);
 
-  if (auth.role === 'guest' && !isAllowedGuestPath(request.nextUrl.pathname)) {
-    return Response.redirect(new URL('/sign-in', request.url));
+    if (auth.role === 'init' && !request.nextUrl.pathname.startsWith('/grade-upload')) {
+      return Response.redirect(new URL('/grade-upload', request.url));
+    }
+
+    if (auth.role === 'guest' && !isAllowedGuestPath(request.nextUrl.pathname)) {
+      return Response.redirect(new URL('/sign-in', request.url));
+    }
   }
 }
 


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x]  인증 절차 로직을 개발하고, 동작을 검증하기 위해 모킹했습니다.
- [x]  인증 여부에 따른 페이지 라우팅을 미들웨어로 구현했습니다.
- [x]  로그인 성공 시 마이페이지로 리다이렉트하는 기능으로 동작을 변경했습니다.

## 🤔 고민 했던 부분
- 개발한 부분은 Next middleware에서 인증 여부에 따른 페이지 라우팅을 하는 부분이므로, 테스트 방법이 애매하여 테스트 코드를 작성하지 못했습니다. 이런 상황을 테스트하려면 cypress와 같은 e2e 수준의 테스트 도구가 필요해 보입니다.
- sign-in 성공 시, useRouter로 리다이렉트 할지, redirect() 함수로 리다이렉트 할지 두 가지 선택지가 있었습니다. useRouter는 클라이언트 사이드에서 라우팅이기 때문에 아키텍처 상으로 굳이 한 단계를 거칠 필요가 없다고 판단하여 redirect()를 사용했습니다.
    - 참고 문헌: https://nextjs.org/docs/app/building-your-application/routing/redirecting
- fetch 시 토큰이 필요한 경우, 매번 반복적으로 헤더에 넣어줘야 하는 불편함이 있습니다. 이를 해결하기 위해 프로젝트 초반에 논의했던 fetch를 wrapping하는 작업이 필요하며, 만약 이 작업을 수행한다면 지금이 적절한 타이밍일 것 같습니다. fetch wrapping 시에는 헤더 설정과 에러 처리 설정 기능 등이 필요해 보입니다.
- 사용자 정보를 통해 PDF 파일 제출 여부를 판단해야 하는데, 아직 API가 명확히 정의되지 않아 임시로 처리하였습니다. API가 확정되면 이를 수정할 예정입니다.
- 개발 편의성을 위해, searchParam에 ?isAuth=true일 때만 미들웨어가 작동하도록 설정했습니다. 필요할 때 사용하고, 그 외의 시간에는 사용하지 않아도 됩니다.
## 🔊 도움이 필요한 부분

