### PR TITLE
change manage modal state jotai/#69

### DIFF
--- a/app/(sub-page)/layout.tsx
+++ b/app/(sub-page)/layout.tsx
@@ -5,7 +5,7 @@ interface LayoutProps {
   children: React.ReactNode;
 }
 
-function Layout({ children }: LayoutProps) {
+function SubPageLayout({ children }: LayoutProps) {
   return (
     <>
       <Image src={background} width={800} height={288} className="w-full bg-white h-[18rem]" alt="background" />
@@ -14,4 +14,4 @@ function Layout({ children }: LayoutProps) {
   );
 }
 
-export default Layout;
+export default SubPageLayout;

--- a/app/(sub-page)/result/layout.tsx
+++ b/app/(sub-page)/result/layout.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import ResultCategoryDetail from '@/app/ui/result/result-category-detail/result-category-detail';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+function Layout({ children }: LayoutProps) {
+  return (
+    <>
+      <ResultCategoryDetail />
+      {children}
+    </>
+  );
+}
+
+export default Layout;

--- a/app/(sub-page)/result/layout.tsx
+++ b/app/(sub-page)/result/layout.tsx
@@ -2,11 +2,11 @@
 
 import ResultCategoryDetail from '@/app/ui/result/result-category-detail/result-category-detail';
 
-interface LayoutProps {
+interface ResultLayoutProps {
   children: React.ReactNode;
 }
 
-function Layout({ children }: LayoutProps) {
+function ResultLayout({ children }: ResultLayoutProps) {
   return (
     <>
       <ResultCategoryDetail />
@@ -15,4 +15,4 @@ function Layout({ children }: LayoutProps) {
   );
 }
 
-export default Layout;
+export default ResultLayout;

--- a/app/hooks/useModal.tsx
+++ b/app/hooks/useModal.tsx
@@ -1,11 +1,20 @@
-import { useState } from 'react';
+import { ModalKey } from '../utils/key/modal.key';
+import { updateModalAtom } from '../store/modal';
+import { useAtom } from 'jotai';
 
-export default function useModal() {
-  const [visible, setVisible] = useState(false);
+export default function useModal(key: ModalKey) {
+  const [isOpenModalList, setOpenModalList] = useAtom(updateModalAtom);
 
-  const toggle = () => {
-    setVisible((prev) => !prev);
+  const isOpen = isOpenModalList[key];
+
+  const close = () => {
+    setOpenModalList([key, false]);
   };
 
-  return { visible, toggle };
+  const toggle = () => {
+    const prevState = isOpenModalList[key];
+    setOpenModalList([key, !prevState]);
+  };
+
+  return { isOpen, close, toggle };
 }

--- a/app/store/modal.ts
+++ b/app/store/modal.ts
@@ -1,0 +1,14 @@
+import { atom } from 'jotai';
+
+const initialState = {
+  RESULT_CATEGORY: false,
+};
+
+const modalAtom = atom(initialState);
+
+export const updateModalAtom = atom(
+  (get) => get(modalAtom),
+  (get, set, [key, value]) => {
+    set(modalAtom, { ...get(modalAtom), [key]: value });
+  },
+);

--- a/app/store/modal.ts
+++ b/app/store/modal.ts
@@ -1,7 +1,8 @@
 import { atom } from 'jotai';
+import { MODAL_KEY } from '../utils/key/modal.key';
 
 const initialState = {
-  RESULT_CATEGORY: false,
+  [MODAL_KEY.RESULT_CATEGORY]: false,
 };
 
 const modalAtom = atom(initialState);

--- a/app/ui/result/result-category-detail/result-category-detail.tsx
+++ b/app/ui/result/result-category-detail/result-category-detail.tsx
@@ -1,0 +1,56 @@
+import LabelContainer from '@/app/ui/view/atom/label-container/label-container';
+import Modal from '../../view/molecule/modal/modal';
+import { cn } from '@/app/utils/shadcn/utils';
+import { useMediaQuery } from 'usehooks-ts';
+import { Table } from '../../view/molecule/table';
+// import CategoryFullfill from '@/app/(sub-page)/result/components/completed-category';
+import { MODAL_KEY } from '@/app/utils/key/modal.key';
+
+function ResultCategoryDetail() {
+  const isDesktop = useMediaQuery('(min-width: 768px)');
+  return (
+    <>
+      {isDesktop ? (
+        <Modal modalKey={MODAL_KEY.RESULT_CATEGORY}>
+          <ResultCategoryDetailContent />
+        </Modal>
+      ) : (
+        // <Drawer>
+        //   <ResultCategoryDetailContent />
+        // </Drawer>
+        <></>
+      )}
+    </>
+  );
+}
+
+export default ResultCategoryDetail;
+
+const headerInfo = ['과목코드', '과목명', '학점'];
+
+function ResultCategoryDetailContent() {
+  const DUMMYDATA = [
+    { id: 0, code: 'HEC01208', name: '데이터구조와알고리즘', credit: 3 },
+    { id: 0, code: 'HEC01208', name: '데이터구조와알고리즘', credit: 3 },
+  ];
+
+  return (
+    <div className="md:w-[80vw] max-w-[1200px] p-2">
+      <div className="flex justify-between">
+        <div>
+          <h1 className={cn('text-2xl font-bold', 'md:text-4xl')}>전공필수</h1>
+          <p className={cn('text-sm text-gray-6 font-medium my-6', 'md:text-lg')}>
+            전공필수 과목 중 미이수과목이 표시됩니다.
+          </p>
+        </div>
+        <div className={cn('text-2xl font-bold', 'md:text-4xl')}>
+          <span className="text-point-blue">18</span> / 18
+        </div>
+      </div>
+      <LabelContainer label="전공필수" rightElement={<div className="text-2xl text-gray-6">18 / 18</div>} />
+      {/* <CategoryFullfill /> */}
+      <LabelContainer label="전공선택" rightElement={<div className="text-2xl text-gray-6">18 / 18</div>} />
+      <Table headerInfo={headerInfo} data={DUMMYDATA} />
+    </div>
+  );
+}

--- a/app/ui/view/molecule/category-card/category-card.tsx
+++ b/app/ui/view/molecule/category-card/category-card.tsx
@@ -1,10 +1,16 @@
+'use client';
 import { cn } from '@/app/utils/shadcn/utils';
 import Button from '../../atom/button/button';
 import PieChart from '../pie-chart/pie-chart';
 import Book from '@/public/assets/book.svg';
 import Image from 'next/image';
+import useModal from '@/app/hooks/useModal';
+import * as React from 'react';
+import { MODAL_KEY } from '@/app/utils/key/modal.key';
 
 function CategoryCard() {
+  const { toggle } = useModal(MODAL_KEY.RESULT_CATEGORY);
+
   return (
     <div
       className={cn('flex flex-col gap-6 zIndex-1 rounded-xl shadow-lg bg-white p-[0.4rem]', 'md:w-80 md:p-[1.8rem]')}
@@ -27,7 +33,7 @@ function CategoryCard() {
             <span className="font-bold text-point-blue">18</span>
           </div>
         </div>
-        <Button size="sm" label="과목 확인" />
+        <Button size="sm" label="과목 확인" onClick={toggle} />
       </div>
     </div>
   );

--- a/app/ui/view/molecule/modal/modal.tsx
+++ b/app/ui/view/molecule/modal/modal.tsx
@@ -3,32 +3,37 @@
 import { Portal, Overlay, Content, Root } from '@radix-ui/react-dialog';
 
 import { cn } from '../../../../utils/shadcn/utils';
-
-interface ModalProps extends React.PropsWithChildren {
-  open: boolean;
-  onOpenChange: () => void;
-}
+import useModal from '@/app/hooks/useModal';
+import { ModalKey } from '@/app/utils/key/modal.key';
 
 const fadeAnimation =
   'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0';
 const noneSlideAnimation =
   'data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]';
 
-const Modal = ({ children, open, onOpenChange }: ModalProps) => (
-  <Root open={open} onOpenChange={onOpenChange}>
-    <Portal>
-      <Overlay className={cn('fixed inset-0 zIndex-3 bg-black/50', fadeAnimation)} />
-      <Content
-        className={cn(
-          'outline-none fixed left-[50%] top-[50%] zIndex-3 max-w-[90%] min-w-[30%] overflow-y-auto translate-x-[-50%] translate-y-[-50%] bg-white p-6 shadow-lg duration-200 rounded-lg max-h-[70vh] lg:max-h-[90vh]',
-          noneSlideAnimation,
-          fadeAnimation,
-        )}
-      >
-        {children}
-      </Content>
-    </Portal>
-  </Root>
-);
+interface ModalProp extends React.PropsWithChildren {
+  modalKey: ModalKey;
+}
+
+const Modal = ({ modalKey, children }: ModalProp) => {
+  const { isOpen, toggle } = useModal(modalKey);
+
+  return (
+    <Root open={isOpen} onOpenChange={toggle}>
+      <Portal>
+        <Overlay className={cn('fixed inset-0 zIndex-3 bg-black/50', fadeAnimation)} />
+        <Content
+          className={cn(
+            'outline-none fixed left-[50%] top-[50%] zIndex-3 max-w-[90%] min-w-[30%] overflow-y-auto translate-x-[-50%] translate-y-[-50%] bg-white p-6 shadow-lg duration-200 rounded-lg max-h-[70vh] lg:max-h-[90vh]',
+            noneSlideAnimation,
+            fadeAnimation,
+          )}
+        >
+          {children}
+        </Content>
+      </Portal>
+    </Root>
+  );
+};
 
 export default Modal;

--- a/app/utils/key/modal.key.ts
+++ b/app/utils/key/modal.key.ts
@@ -1,0 +1,5 @@
+export const MODAL_KEY = {
+  RESULT_CATEGORY: 'RESULT_CATEGORY',
+} as const;
+
+export type ModalKey = (typeof MODAL_KEY)[keyof typeof MODAL_KEY];


### PR DESCRIPTION
## **📌** 작업 내용


close #69 

> 구현 내용 및 작업 했던 내역

- [x] modal 확장성을 높이고, 참조관계를 완전히 분리하기 위해 상태관리를 useState에서 jotai로 변경했습니다.

## 🤔 고민 했던 부분

- ResultCategoryDetail의 반응형 부분은 반영되지않은 사항이니 modal부분만 확인해주시면 됩니다.

## 🔊 도움이 필요한 부분

- Modal을 result페이지에서 사용하고 있어 result페이지의 layout에 위치시켰는데, 관리 및 응집성을 위해서 modal을 모아두는 component를 생성할까 고민이 되었습니다. 이 부분에 대한 팀원들의 생각이 궁금합니다.


