### PR TITLE
Auth client/#62

### DIFF
--- a/app/(sub-page)/error.tsx
+++ b/app/(sub-page)/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  if (error.message === 'Unauthorized') {
+    return (
+      <div>
+        <h2>Unauthorized</h2>
+        <Link href="/sign-in">to Login</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Something went wrong!!!!!</h2>
+      <button
+        onClick={
+          // 세그먼트를 재 렌더링 하여 복구를 시도합니다.
+          () => reset()
+        }
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/app/(sub-page)/protected/page.tsx
+++ b/app/(sub-page)/protected/page.tsx
@@ -2,7 +2,9 @@ import { API_PATH } from '@/app/business/api-path';
 import { httpErrorHandler } from '@/app/utils/http/http-error-handler';
 
 async function trigger() {
-  const response = await fetch(`${API_PATH.auth}/failure`);
+  const response = await fetch(`${API_PATH.auth}/failure`, {
+    cache: 'no-store',
+  });
   const result = await response.json();
   httpErrorHandler(response, result);
 }

--- a/app/(sub-page)/protected/page.tsx
+++ b/app/(sub-page)/protected/page.tsx
@@ -1,0 +1,13 @@
+import { API_PATH } from '@/app/business/api-path';
+import { httpErrorHandler } from '@/app/utils/http/http-error-handler';
+
+export async function trigger() {
+  const response = await fetch(`${API_PATH.auth}/failure`);
+  const result = await response.json();
+  httpErrorHandler(response, result);
+}
+
+export default async function ProtectedPage() {
+  const data = await trigger();
+  return <div>Auth protected</div>;
+}

--- a/app/(sub-page)/protected/page.tsx
+++ b/app/(sub-page)/protected/page.tsx
@@ -1,7 +1,7 @@
 import { API_PATH } from '@/app/business/api-path';
 import { httpErrorHandler } from '@/app/utils/http/http-error-handler';
 
-export async function trigger() {
+async function trigger() {
   const response = await fetch(`${API_PATH.auth}/failure`);
   const result = await response.json();
   httpErrorHandler(response, result);

--- a/app/business/user/user.command.ts
+++ b/app/business/user/user.command.ts
@@ -15,7 +15,7 @@ import { cookies } from 'next/headers';
 import { isValidation } from '@/app/utils/zod/validation.util';
 import { redirect } from 'next/navigation';
 
-export async function validateToken(): Promise<ValidateTokenResponse | boolean> {
+export async function validateToken(): Promise<ValidateTokenResponse | false> {
   const accessToken = cookies().get('accessToken')?.value;
   const refreshToken = cookies().get('refreshToken')?.value;
   try {

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { useEffect } from 'react';
+
+// https://nextjs.org/docs/app/building-your-application/routing/error-handling#handling-errors-in-root-layouts
+// global-error는 프로덕션에서만 활성화
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <h2>Something went wrong!!!!!</h2>
+        <button
+          onClick={
+            // 세그먼트를 재 렌더링 하여 복구를 시도합니다.
+            () => reset()
+          }
+        >
+          Try again
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/app/mocks/handlers/user-handler.mock.ts
+++ b/app/mocks/handlers/user-handler.mock.ts
@@ -22,6 +22,10 @@ function mockDecryptToken(token: string) {
 }
 
 export const userHandlers = [
+  http.get<never, never, never>(`${API_PATH.auth}/failure`, async ({ request }) => {
+    await delay(500);
+    return HttpResponse.json({ status: 401, message: 'Unauthorized' }, { status: 401 });
+  }),
   http.post<never, never, ValidateTokenResponse>(`${API_PATH.auth}/token`, async ({ request }) => {
     return HttpResponse.json({
       accessToken: 'fake-access-token',

--- a/app/ui/view/molecule/list/swipeable-custom-list.tsx
+++ b/app/ui/view/molecule/list/swipeable-custom-list.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { ListRow } from './list-root';
-import { SwipeableList, Type as ListType } from 'react-swipeable-list';
+// import { SwipeableList, Type as ListType } from 'react-swipeable-list';
 
 interface SwipeableListProps<T extends ListRow> {
   data: T[];
@@ -10,7 +10,7 @@ interface SwipeableListProps<T extends ListRow> {
 export default function SwipeableCustomList<T extends ListRow>({ data, render }: SwipeableListProps<T>) {
   return (
     <div className="rounded-xl border-[1px] border-gray-300 w-full ">
-      <SwipeableList type={ListType.IOS}>{data.map((item, index) => render(item, index))}</SwipeableList>
+      {/* <SwipeableList type={ListType.IOS}>{data.map((item, index) => render(item, index))}</SwipeableList> */}
     </div>
   );
 }

--- a/app/ui/view/molecule/table/table.stories.tsx
+++ b/app/ui/view/molecule/table/table.stories.tsx
@@ -87,7 +87,7 @@ export const SwipeableLectureTable: StoryObj = {
         credit: 3,
       },
     ];
-    const actionButton = () => <DeleteTakenLectureButton lectureId={3} handleDelete={() => {}} />;
+    const actionButton = () => <DeleteTakenLectureButton lectureId={3} onDelete={() => {}} />;
     return (
       <main>
         <Table


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x] 클라이언트 수준 발생하는 에러 처리 로직 작성
- [x] 에러 바운더리 컴포넌트 개발
- [x] 빌드 깨지는 버그들을 일부 수정했습니다.

## 🤔 고민 했던 부분
- 에러 바운더리의 동작 과정
    - 처음에는 이벤트 핸들러 내부의 서버 액션이 인증 관련 에러를 발생시킬 때, 에러 바운더리에서 일관되게 처리하려고 했습니다.
    - 그러나 이벤트 핸들러에서 에러가 발생하더라도 에러 바운더리가 작동하지 않았습니다. 이유를 찾아보니, 이벤트 핸들러에서 발생한 에러는 에러 바운더리가 잡지 않는다고 합니다.
        - https://legacy.reactjs.org/docs/error-boundaries.html#how-about-event-handlers
    - 이는 에러 바운더리의 존재 목적이 에러 발생 시 사용자에게 이상한 화면을 보여주는 것을 방지하기 위함이며, 이벤트 핸들러의 경우 렌더링 자체에는 문제가 없기 때문인 것 같습니다.
- Next Js global error
    
    > global-error.js is only enabled in production. In development, our error overlay will show instead.
    > 
    - 인증 오류 발생 시 일관되게 로그인 페이지로 이동하는 로직을 처리해야 했습니다.
    - 로직이 일관되므로, 인증 오류는 global-error 컴포넌트에서 처리하는 것이 적절하다고 판단했습니다.
    - 하지만 global-error는 프로덕션 상태에서만 작동한다는 점을 알게 되었습니다.
    - 따라서, 일단은 sub-page 폴더의 error 컴포넌트에서 처리하도록 결정했습니다.
- 서버와 클라이언트의 error 인스턴스
    - 원래 에러 바운더리에서 서브클래싱된 에러 객체를 `error instanceof BadRequestError`와 같이 인스턴스로 분기 처리하려고 했습니다.
    - 서브클래싱은 잘 되지만, 인스턴스로 인한 분기 처리가  작동하지 않았습니다. 그래서 찾아본 결과, 서버 컴포넌트에서 발생한 오류는 서버 코드에서 작동하고, 에러 바운더리는 클라이언트 코드에서 작동해서 인스턴스가 다른 것 같습니다.
        - https://nextjs.org/docs/app/building-your-application/routing/error-handling#handling-server-errors
    - React 공식 문서를 보니, 에러 바운더리는 원래 서버 측 렌더링에서 발생한 오류를 포착하지 않는다고 합니다. 그래서 Next가 자체적으로 서버 측에서 발생한 오류를 클라이언트 컴포넌트인 에러 바운더리에 연결해주는 작업을 하는 것 같은데, 인스턴스까지 복제는 안되고, 내용만 같게 해주는 것 같습니다.
        - https://legacy.reactjs.org/docs/error-boundaries.html#introducing-error-boundaries
    - 그래서 message로 분기 처리해서 로직을 작성했습니다. code나 name이 아니라 message로 처리한 이유는 문서에 서버 측에서 발생한 오류는 message 와 digest만 포함된다고 되어 있기 때문입니다.
        - https://nextjs.org/docs/app/building-your-application/routing/error-handling#securing-sensitive-error-information


