### PR TITLE
Use info logic/#82

### DIFF
--- a/app/(sub-page)/my/floating-component-container.tsx
+++ b/app/(sub-page)/my/floating-component-container.tsx
@@ -1,0 +1,9 @@
+import UserDeleteModal from '@/app/ui/user/user-info-navigator/user-delete-modal';
+
+export default function FloatingComponentContainer() {
+  return (
+    <>
+      <UserDeleteModal />
+    </>
+  );
+}

--- a/app/(sub-page)/my/page.tsx
+++ b/app/(sub-page)/my/page.tsx
@@ -5,6 +5,7 @@ import ContentContainer from '@/app/ui/view/atom/content-container';
 import Drawer from '@/app/ui/view/molecule/drawer/drawer';
 import { DIALOG_KEY } from '@/app/utils/key/dialog.key';
 import { Suspense } from 'react';
+import FloatingComponentContainer from './floating-component-container';
 
 export default function MyPage() {
   return (
@@ -22,6 +23,7 @@ export default function MyPage() {
       <Drawer drawerKey={DIALOG_KEY.LECTURE_SEARCH}>
         <LectureSearch />
       </Drawer>
+      <FloatingComponentContainer />
     </>
   );
 }

--- a/app/__test__/ui/user/user-info-navigator.test.tsx
+++ b/app/__test__/ui/user/user-info-navigator.test.tsx
@@ -1,0 +1,21 @@
+import '@testing-library/jest-dom';
+import UserInfoNavigator from '@/app/ui/user/user-info-navigator/user-info-navigator';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue({
+      value: 'fake-access-token',
+    }),
+  }),
+}));
+
+describe('UserInfoNavigator', () => {
+  it('UserInfoNavigator를 렌더링한다.', async () => {
+    render(await UserInfoNavigator());
+
+    expect(await screen.findByText(/모킹이/i)).toBeInTheDocument();
+    expect(await screen.findByText(/융합소프트웨어/i)).toBeInTheDocument();
+    expect(await screen.findByText(/60000000/i)).toBeInTheDocument();
+  });
+});

--- a/app/business/user/user.command.ts
+++ b/app/business/user/user.command.ts
@@ -2,7 +2,7 @@
 
 import { FormState } from '@/app/ui/view/molecule/form/form-root';
 import { API_PATH } from '../api-path';
-import { SignUpRequestBody, SignInRequestBody, ValidateTokenResponse } from './user.type';
+import { SignUpRequestBody, SignInRequestBody, ValidateTokenResponse, UserDeleteRequestBody } from './user.type';
 import { httpErrorHandler } from '@/app/utils/http/http-error-handler';
 import { BadRequestError } from '@/app/utils/http/http-error';
 import {
@@ -23,42 +23,42 @@ export async function signOut() {
 }
 
 export async function deleteUser(prevState: FormState, formData: FormData): Promise<FormState> {
-  // const body: SignUpRequestBody = {
-  //   authId,
-  // };
+  try {
+    const body: UserDeleteRequestBody = {
+      password: formData.get('password') as string,
+    };
 
-  // try {
-  //   const response = await fetch(`${API_PATH.user}/sign-up`, {
-  //     method: 'POST',
-  //     headers: {
-  //       'Content-Type': 'application/json',
-  //     },
-  //     body: JSON.stringify(body),
-  //   });
+    const response = await fetch(`${API_PATH.user}/delete-me`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${cookies().get('accessToken')?.value}`,
+      },
+      body: JSON.stringify(body),
+    });
+    const result = await response.json();
 
-  //   const result = await response.json();
-
-  //   httpErrorHandler(response, result);
-  // } catch (error) {
-  //   if (error instanceof BadRequestError) {
-  //     // 잘못된 요청 처리 로직
-  //     return {
-  //       isSuccess: false,
-  //       isFailure: true,
-  //       validationError: {},
-  //       message: error.message,
-  //     };
-  //   } else {
-  //     // 나머지 에러는 더 상위 수준에서 처리
-  //     throw error;
-  //   }
-  // }
+    httpErrorHandler(response, result);
+  } catch (error) {
+    if (error instanceof BadRequestError) {
+      // 잘못된 요청 처리 로직
+      return {
+        isSuccess: false,
+        isFailure: true,
+        validationError: {},
+        message: error.message,
+      };
+    } else {
+      // 나머지 에러는 더 상위 수준에서 처리
+      throw error;
+    }
+  }
 
   return {
     isSuccess: true,
     isFailure: false,
     validationError: {},
-    message: '회원가입이 완료되었습니다.',
+    message: '회원 탈퇴가 완료되었습니다.',
   };
 }
 

--- a/app/business/user/user.command.ts
+++ b/app/business/user/user.command.ts
@@ -15,6 +15,13 @@ import { cookies } from 'next/headers';
 import { isValidation } from '@/app/utils/zod/validation.util';
 import { redirect } from 'next/navigation';
 
+export async function signOut() {
+  cookies().delete('accessToken');
+  cookies().delete('refreshToken');
+
+  redirect('/sign-in');
+}
+
 export async function validateToken(): Promise<ValidateTokenResponse | false> {
   const accessToken = cookies().get('accessToken')?.value;
   const refreshToken = cookies().get('refreshToken')?.value;

--- a/app/business/user/user.command.ts
+++ b/app/business/user/user.command.ts
@@ -22,6 +22,46 @@ export async function signOut() {
   redirect('/sign-in');
 }
 
+export async function deleteUser(prevState: FormState, formData: FormData): Promise<FormState> {
+  // const body: SignUpRequestBody = {
+  //   authId,
+  // };
+
+  // try {
+  //   const response = await fetch(`${API_PATH.user}/sign-up`, {
+  //     method: 'POST',
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //     },
+  //     body: JSON.stringify(body),
+  //   });
+
+  //   const result = await response.json();
+
+  //   httpErrorHandler(response, result);
+  // } catch (error) {
+  //   if (error instanceof BadRequestError) {
+  //     // 잘못된 요청 처리 로직
+  //     return {
+  //       isSuccess: false,
+  //       isFailure: true,
+  //       validationError: {},
+  //       message: error.message,
+  //     };
+  //   } else {
+  //     // 나머지 에러는 더 상위 수준에서 처리
+  //     throw error;
+  //   }
+  // }
+
+  return {
+    isSuccess: true,
+    isFailure: false,
+    validationError: {},
+    message: '회원가입이 완료되었습니다.',
+  };
+}
+
 export async function validateToken(): Promise<ValidateTokenResponse | false> {
   const accessToken = cookies().get('accessToken')?.value;
   const refreshToken = cookies().get('refreshToken')?.value;

--- a/app/business/user/user.type.ts
+++ b/app/business/user/user.type.ts
@@ -16,6 +16,10 @@ export interface SignInRequestBody {
   password: string;
 }
 
+export interface UserDeleteRequestBody {
+  password: string;
+}
+
 export type SignInResponse = z.infer<typeof SignInResponseSchema>;
 
 export type UserInfoResponse = z.infer<typeof UserInfoResponseSchema>;

--- a/app/mocks/db.mock.ts
+++ b/app/mocks/db.mock.ts
@@ -28,6 +28,7 @@ type MockDatabaseAction = {
   createUser: (user: SignUpRequestBody) => boolean;
   signIn: (userData: SignInRequestBody) => boolean;
   getUserInfo: (authId: string) => UserInfoResponse;
+  deleteUser: (authId: string, password: string) => boolean;
 };
 
 export const mockDatabase: MockDatabaseAction = {
@@ -92,6 +93,14 @@ export const mockDatabase: MockDatabaseAction = {
       major: user.major,
       isSumbitted: user.isSumbitted,
     };
+  },
+  deleteUser: (authId: string, password: string) => {
+    const user = mockDatabaseStore.users.find((u) => u.authId === authId && u.password === password);
+    if (user) {
+      mockDatabaseStore.users = mockDatabaseStore.users.filter((u) => u.authId !== authId);
+      return true;
+    }
+    return false;
   },
 };
 

--- a/app/mocks/db.mock.ts
+++ b/app/mocks/db.mock.ts
@@ -66,7 +66,7 @@ export const mockDatabase: MockDatabaseAction = {
       {
         ...user,
         isSumbitted: false,
-        major: '융소입니다',
+        major: '융합소프트웨어',
         name: '모킹이2',
       },
     ];
@@ -105,7 +105,7 @@ const initialState: MockDatabaseState = {
       studentNumber: '60000000',
       engLv: 'ENG12',
       isSumbitted: false,
-      major: '융소입니다',
+      major: '융합소프트웨어',
       name: '모킹이',
     },
   ],

--- a/app/store/dialog.ts
+++ b/app/store/dialog.ts
@@ -5,6 +5,7 @@ const initialState = {
   [DIALOG_KEY.RESULT_CATEGORY]: false,
   [DIALOG_KEY.DIALOG_TEST]: true,
   [DIALOG_KEY.LECTURE_SEARCH]: false,
+  [DIALOG_KEY.USER_DEELETE]: false,
 };
 
 const dialogAtom = atom(initialState);

--- a/app/ui/user/user-info-navigator/sign-out-button.tsx
+++ b/app/ui/user/user-info-navigator/sign-out-button.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { signOut } from '@/app/business/user/user.command';
+import Button from '../../view/atom/button/button';
+
+export default function SignOutButton() {
+  const handleSignOut = async () => {
+    await signOut();
+  };
+
+  return <Button onClick={handleSignOut} size="sm" variant="secondary" label="로그아웃" />;
+}

--- a/app/ui/user/user-info-navigator/user-delete-button.tsx
+++ b/app/ui/user/user-info-navigator/user-delete-button.tsx
@@ -1,5 +1,14 @@
+'use client';
 import Button from '../../view/atom/button/button';
+import { DIALOG_KEY } from '@/app/utils/key/dialog.key';
+import useDialog from '@/app/hooks/useDialog';
 
 export default function UserDeleteButton() {
-  return <Button size="sm" variant="text" label="회원탈퇴하기" />;
+  const { toggle } = useDialog(DIALOG_KEY.USER_DEELETE);
+
+  const handleModalToggle = () => {
+    toggle();
+  };
+
+  return <Button onClick={handleModalToggle} size="sm" variant="text" label="회원탈퇴하기" />;
 }

--- a/app/ui/user/user-info-navigator/user-delete-button.tsx
+++ b/app/ui/user/user-info-navigator/user-delete-button.tsx
@@ -1,0 +1,5 @@
+import Button from '../../view/atom/button/button';
+
+export default function UserDeleteButton() {
+  return <Button size="sm" variant="text" label="회원탈퇴하기" />;
+}

--- a/app/ui/user/user-info-navigator/user-delete-modal.tsx
+++ b/app/ui/user/user-info-navigator/user-delete-modal.tsx
@@ -1,0 +1,10 @@
+import { DIALOG_KEY } from '@/app/utils/key/dialog.key';
+import Modal from '../../view/molecule/modal/modal';
+
+export default function UserDeleteModal() {
+  return (
+    <Modal modalKey={DIALOG_KEY.USER_DEELETE}>
+      <div className="text-center"></div>
+    </Modal>
+  );
+}

--- a/app/ui/user/user-info-navigator/user-delete-modal.tsx
+++ b/app/ui/user/user-info-navigator/user-delete-modal.tsx
@@ -4,7 +4,7 @@ import Modal from '../../view/molecule/modal/modal';
 export default function UserDeleteModal() {
   return (
     <Modal modalKey={DIALOG_KEY.USER_DEELETE}>
-      <div className="text-center"></div>
+      <div className="text-center">test</div>
     </Modal>
   );
 }

--- a/app/ui/user/user-info-navigator/user-delete-modal.tsx
+++ b/app/ui/user/user-info-navigator/user-delete-modal.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { DIALOG_KEY } from '@/app/utils/key/dialog.key';
 import Modal from '../../view/molecule/modal/modal';
 import Form from '../../view/molecule/form';
@@ -13,7 +14,7 @@ export default function UserDeleteModal() {
           회원탈퇴를 진행하시겠습니까? 탈퇴를 진행하면더 비밀번호 입력이 필요합니다.
         </p>
         <div className="my-4">
-          <Form action={deleteUser} id={'user-delete'}>
+          <Form failMessageControl={'toast'} action={deleteUser} id={'user-delete'}>
             <Form.PasswordInput label="비밀번호" id="password" placeholder="비밀번호를 입력하세요" required={true} />
             <Form.SubmitButton label="탈퇴하기" position="center" variant="primary" />
           </Form>

--- a/app/ui/user/user-info-navigator/user-delete-modal.tsx
+++ b/app/ui/user/user-info-navigator/user-delete-modal.tsx
@@ -1,10 +1,25 @@
 import { DIALOG_KEY } from '@/app/utils/key/dialog.key';
 import Modal from '../../view/molecule/modal/modal';
+import Form from '../../view/molecule/form';
+import { deleteUser } from '@/app/business/user/user.command';
 
 export default function UserDeleteModal() {
   return (
     <Modal modalKey={DIALOG_KEY.USER_DEELETE}>
-      <div className="text-center">test</div>
+      <div className="max-w-sm mx-auto my-12 p-6 border rounded-lg shadow-md bg-white">
+        <h2 className="text-xl font-bold text-center">회원 탈퇴</h2>
+        <div className="h-1 w-10 bg-blue-600 mx-auto my-3" />
+        <p className="text-sm text-center my-4">
+          회원탈퇴를 진행하시겠습니까? 탈퇴를 진행하면더 비밀번호 입력이 필요합니다.
+        </p>
+        <div className="my-4">
+          <Form action={deleteUser} id={'user-delete'}>
+            <Form.PasswordInput label="비밀번호" id="password" placeholder="비밀번호를 입력하세요" required={true} />
+            <Form.SubmitButton label="탈퇴하기" position="center" variant="primary" />
+          </Form>
+        </div>
+        <p className="text-xs text-center my-4">정보를 누락하여 서비스를 이용해 주셔서 감사합니다.</p>
+      </div>
     </Modal>
   );
 }

--- a/app/ui/user/user-info-navigator/user-info-navigator.tsx
+++ b/app/ui/user/user-info-navigator/user-info-navigator.tsx
@@ -3,6 +3,7 @@ import Button from '../../view/atom/button/button';
 import { getUserInfo } from '@/app/business/user/user.query';
 import Skeleton from '../../view/atom/skeleton';
 import SignOutButton from './sign-out-button';
+import UserDeleteButton from './user-delete-button';
 
 export default async function UserInfoNavigator() {
   const userInfo = await getUserInfo();
@@ -22,7 +23,7 @@ export default async function UserInfoNavigator() {
         <SignOutButton />
       </div>
       <div className="mt-2">
-        <Button size="sm" variant="text" label="회원탈퇴하기" />
+        <UserDeleteButton />
       </div>
     </div>
   );

--- a/app/ui/user/user-info-navigator/user-info-navigator.tsx
+++ b/app/ui/user/user-info-navigator/user-info-navigator.tsx
@@ -2,6 +2,7 @@ import Avatar from '../../view/atom/avatar/avatar';
 import Button from '../../view/atom/button/button';
 import { getUserInfo } from '@/app/business/user/user.query';
 import Skeleton from '../../view/atom/skeleton';
+import SignOutButton from './sign-out-button';
 
 export default async function UserInfoNavigator() {
   const userInfo = await getUserInfo();
@@ -18,7 +19,7 @@ export default async function UserInfoNavigator() {
       <div className="text-sm text-gray-400">{userInfo.studentNumber}</div>
 
       <div className="mt-9">
-        <Button size="sm" variant="secondary" label="로그아웃" />
+        <SignOutButton />
       </div>
       <div className="mt-2">
         <Button size="sm" variant="text" label="회원탈퇴하기" />

--- a/app/utils/key/dialog.key.ts
+++ b/app/utils/key/dialog.key.ts
@@ -2,6 +2,7 @@ export const DIALOG_KEY = {
   RESULT_CATEGORY: 'RESULT_CATEGORY',
   DIALOG_TEST: 'DIALOG_TEST',
   LECTURE_SEARCH: 'LECTURE_SEARCH',
+  USER_DEELETE: 'USER_DEELETE',
 } as const;
 
 export type DialogKey = (typeof DIALOG_KEY)[keyof typeof DIALOG_KEY];

--- a/middleware.ts
+++ b/middleware.ts
@@ -31,10 +31,12 @@ async function getAuth(request: NextRequest): Promise<{
   };
 }
 
-const allowdGuestPath = ['/tutorial', '/sign-in', '/sign-up', '/find-password', '/find-id'];
+const allowdOnlyGuestPath = ['/sign-in', '/sign-up', '/find-password', '/find-id'];
+const allowdGuestPath = ['/', '/tutorial', ...allowdOnlyGuestPath];
 
-function isAllowedGuestPath(path: string) {
-  return allowdGuestPath.some((allowedPath) => path.startsWith(allowedPath));
+function isAllowedGuestPath(path: string, strict: boolean = false) {
+  const allowdPath = strict ? allowdOnlyGuestPath : allowdGuestPath;
+  return allowdPath.some((allowedPath) => path.startsWith(allowedPath));
 }
 
 export async function middleware(request: NextRequest) {
@@ -50,6 +52,10 @@ export async function middleware(request: NextRequest) {
 
     if (auth.role === 'guest' && !isAllowedGuestPath(request.nextUrl.pathname)) {
       return Response.redirect(new URL('/sign-in', request.url));
+    }
+
+    if (auth.role !== 'guest' && isAllowedGuestPath(request.nextUrl.pathname, true)) {
+      return Response.redirect(new URL('/my', request.url));
     }
   }
 }


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x]  로그아웃 및 회원탈퇴 로직, 그리고 컴포넌트 구현
- [x]  mock에서 인증 관련 로직 수정
- [x]  미들웨어 라우팅 로직 수정

## 🤔 고민 했던 부분
- 인증 로직으로 테스트가 어려워지는 문제를 해결하기 위해, 개발 모드일 때만 인증 처리를 하는 devModeAuthGuard() 함수를 구현했습니다.
- 또 다른 해결책은 next/header의 쿠키를 모의하는 것입니다. 이에 대해 user-info-navigator 컴포넌트에서 작성했습니다.
- 어느 정도까지 mock을 유지하고 관리해야 하는지에 대한 고민은 항상 있는 것 같습니다. 개발의 편의성을 위해 AuthGuard()를 제거할 수도 있지만, 나중에 동작을 정확하게 모의해야 할 필요가 있을 때 사용하시면 됩니다.

## 🔊 도움이 필요한 부분
- user.command 파일이 너무 크네요. 로직별로 파일을 분리하는 것을 고려하고 있는데. 여러분의 의견을 듣고 싶어요.