### PR TITLE
Use suspense query error/#120

### DIFF
--- a/app/business/services/auth.ts
+++ b/app/business/services/auth.ts
@@ -1,6 +1,7 @@
 'use server';
 import { cookies } from 'next/headers';
 
-export const getToken = (): string | undefined => {
+export const getToken = async (): Promise<string | undefined> => {
   return cookies().get('accessToken')?.value;
 };
+// server action은 async를 써야함

--- a/app/business/services/lecture/taken-lecture.command.ts
+++ b/app/business/services/lecture/taken-lecture.command.ts
@@ -5,6 +5,7 @@ import { httpErrorHandler } from '@/app/utils/http/http-error-handler';
 import { BadRequestError } from '@/app/utils/http/http-error';
 import { revalidateTag } from 'next/cache';
 import { TAG } from '@/app/utils/http/tag';
+import { cookies } from 'next/headers';
 
 export const registerUserGrade = async (prevState: FormState, formData: FormData) => {
   const parsingText = await parsePDFtoText(formData);
@@ -43,29 +44,34 @@ export const parsePDFtoText = async (formData: FormData) => {
 };
 
 export const deleteTakenLecture = async (lectureId: number) => {
-  try {
-    const response = await fetch(API_PATH.takenLectures, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ lectureId }),
-    });
-    const result = await response.json();
-    httpErrorHandler(response, result);
-  } catch (error) {
-    if (error instanceof BadRequestError) {
-      return {
-        isSuccess: false,
-      };
-    } else {
-      throw error;
-    }
+  // try {
+  const response = await fetch(`${API_PATH.takenLectures}/${lectureId}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${cookies().get('accessToken')?.value}`,
+    },
+  });
+  // fetch 가 수정되면서 바꿀 예정이므로 현재는 작동만 되도록 수정
+  if (response.ok) {
+    return {
+      isSuccess: true,
+    };
+  } else {
+    return {
+      isSuccess: false,
+    };
   }
+  // } catch (error) {
+  //   if (error instanceof BadRequestError) {
+  //     return {
+  //       isSuccess: false,
+  //     };
+  //   } else {
+  //     throw error;
+  //   }
+  // }
   revalidateTag(TAG.GET_TAKEN_LECTURES);
-  return {
-    isSuccess: true,
-  };
 };
 
 export const addTakenLecture = async (lectureId: number) => {

--- a/app/business/services/lecture/taken-lecture.query.ts
+++ b/app/business/services/lecture/taken-lecture.query.ts
@@ -4,10 +4,10 @@ import { cookies } from 'next/headers';
 
 export interface TakenLecturesResponse {
   totalCredit: number;
-  takenLectures: TakenLectrueInfoResponse[];
+  takenLectures: TakenLectureInfoResponse[];
 }
 
-interface TakenLectrueInfoResponse {
+interface TakenLectureInfoResponse {
   [index: string]: string | number;
   id: number;
   year: string;

--- a/app/business/services/user/user.query.ts
+++ b/app/business/services/user/user.query.ts
@@ -20,7 +20,7 @@ export async function auth(): Promise<InitUserInfoResponse | UserInfoResponse | 
 
 export async function fetchUser(): Promise<InitUserInfoResponse | UserInfoResponse> {
   try {
-    const response = await fetch(`${API_PATH.user}`, {
+    const response = await fetch(`${API_PATH.user}/me`, {
       headers: {
         Authorization: `Bearer ${cookies().get('accessToken')?.value}`,
       },
@@ -29,7 +29,6 @@ export async function fetchUser(): Promise<InitUserInfoResponse | UserInfoRespon
     const result = await response.json();
 
     httpErrorHandler(response, result);
-
     if (isValidation(result, UserInfoResponseSchema || InitUserInfoResponseSchema)) {
       return result;
     } else {

--- a/app/business/services/user/user.validation.ts
+++ b/app/business/services/user/user.validation.ts
@@ -4,7 +4,7 @@ import { UserInfoResponse, InitUserInfoResponse } from './user.type';
 export const UserInfoResponseSchema = z.object({
   studentNumber: z.string(),
   studentName: z.string(),
-  completionDivision: z.array(
+  completeDivision: z.array(
     z.object({
       majorType: z.enum(['PRIMARY', 'DUAL', 'SUB']),
       major: z.string(),
@@ -18,7 +18,7 @@ export const UserInfoResponseSchema = z.object({
 export const InitUserInfoResponseSchema = z.object({
   studentNumber: z.string(),
   studentName: z.null(),
-  completionDivision: z.null(),
+  completeDivision: z.null(),
   totalCredit: z.null(),
   takenCredit: z.null(),
   graduated: z.null(),

--- a/app/mocks/data.mock.ts
+++ b/app/mocks/data.mock.ts
@@ -72,7 +72,7 @@ export const takenLectures = JSON.parse(`{
 export const userInfo = JSON.parse(`{
     "studentNumber": "60181666",
     "studentName": "장진욱",
-    "completionDivision" : [
+    "completeDivision" : [
         {
             "majorType" : "PRIMARY",
             "major": "디지털콘텐츠디자인학과"
@@ -279,41 +279,45 @@ export const credits = JSON.parse(`[
     }
 ]`);
 
-export const searchLectures = JSON.parse(`{
-	"lectures": [
-        {
-            "id": 1,
-            "lectureCode": "KMA02106",
-            "name": "영어1",
-            "credit": 2,
-            "isTaken" : false
-        },
-        {
-          "id": 2,
-          "lectureCode": "KMA02106",
-          "name": "영어2",
-          "credit": 2,
-          "isTaken" : true
-      },
-      {
-        "id": 3,
-        "lectureCode": "KMA02136",
-        "name": "영어무역이론",
-        "credit": 3,
-        "isTaken" : false
-    },
-    {
-      "id": 1,
-      "lectureCode": "KMA02106",
-      "name": "영어회화3",
-      "credit": 1,
-      "isTaken" : false
-  }, 
+export const searchLectures = [
   {
-    "id": 1,
-    "lectureCode": "KMA02106",
-    "name": "영어회화4",
-    "credit": 2,
-    "isTaken" : true
-}]
-}`);
+    id: 1,
+    lectureCode: 'KMA02106',
+    name: '영어1',
+    credit: 2,
+    taken: false,
+    revoked: true,
+  },
+  {
+    id: 2,
+    lectureCode: 'KMA02106',
+    name: '영어2',
+    credit: 2,
+    taken: true,
+    revoked: false,
+  },
+  {
+    id: 3,
+    lectureCode: 'KMA02136',
+    name: '영어무역이론',
+    credit: 3,
+    taken: false,
+    revoked: false,
+  },
+  {
+    id: 4,
+    lectureCode: 'KMA02106',
+    name: '영어회화3',
+    credit: 1,
+    taken: false,
+    revoked: false,
+  },
+  {
+    id: 6,
+    lectureCode: 'KMA02106',
+    name: '영어회화4',
+    credit: 2,
+    taken: true,
+    revoked: false,
+  },
+];

--- a/app/mocks/db.mock.ts
+++ b/app/mocks/db.mock.ts
@@ -1,4 +1,3 @@
-import { SearchLecturesResponse } from '../store/querys/lecture';
 import { TakenLecturesResponse } from '../business/services/lecture/taken-lecture.query';
 import { CreditResponse, ResultCategoryDetailResponse } from '../store/querys/result';
 import {
@@ -8,20 +7,21 @@ import {
   InitUserInfoResponse,
 } from '../business/services/user/user.type';
 import { takenLectures, credits, searchLectures, userInfo, users, resultCategoryDetailInfo } from './data.mock';
+import { SearchedLectureInfoResponse } from '../store/querys/lecture';
 
 interface MockDatabaseState {
   takenLectures: TakenLecturesResponse;
   resultCategoryDetailInfo: ResultCategoryDetailResponse;
   credits: CreditResponse[];
   users: SignUpRequestBody[];
-  searchLectures: SearchLecturesResponse;
+  searchLectures: SearchedLectureInfoResponse[];
   userInfo: UserInfoResponse;
 }
 
 type MockDatabaseAction = {
   reset: () => void;
   getTakenLectures: () => TakenLecturesResponse;
-  getSearchLectures: () => SearchLecturesResponse;
+  getSearchLectures: () => SearchedLectureInfoResponse[];
   addTakenLecture: (lectureId: number) => boolean;
   deleteTakenLecture: (lectureId: number) => boolean;
   createUser: (user: SignUpRequestBody) => boolean;
@@ -49,7 +49,7 @@ export const mockDatabase: MockDatabaseAction = {
     return false;
   },
   addTakenLecture: (lectureId) => {
-    const lecture = mockDatabaseStore.searchLectures.lectures.find((lecture) => lecture.id === lectureId);
+    const lecture = mockDatabaseStore.searchLectures.find((lecture) => lecture.id === lectureId);
     if (!lecture) {
       return false;
     }
@@ -85,7 +85,7 @@ export const mockDatabase: MockDatabaseAction = {
       return {
         studentNumber: '',
         studentName: null,
-        completionDivision: null,
+        completeDivision: null,
         totalCredit: null,
         takenCredit: null,
         graduated: null,

--- a/app/mocks/handlers/taken-lecture-handler.mock.ts
+++ b/app/mocks/handlers/taken-lecture-handler.mock.ts
@@ -21,9 +21,11 @@ export const takenLectureHandlers = [
     if (isAdded) return HttpResponse.json({ message: '과목 추가에 성공했습니다' }, { status: 200 });
     return HttpResponse.json({ errorCode: 400, message: '추가에 실패했습니다' }, { status: 400 });
   }),
-  http.delete<never, { lectureId: number }>(API_PATH.takenLectures, async ({ request }) => {
-    const body = await request.json();
-    const isDeleted = mockDatabase.deleteTakenLecture(body.lectureId);
+  http.delete<never, { lectureId: number }>(`${API_PATH.takenLectures}/:id`, async ({ request }) => {
+    const url = new URL(request.url);
+    // url.pathname.split("/") 의 결과 : ['','taken-lectures',120]
+    const lectureId = Number(url.pathname.split('/')[2]);
+    const isDeleted = mockDatabase.deleteTakenLecture(lectureId);
     await delay(1000);
     if (isDeleted) {
       return HttpResponse.json({ message: '삭제되었습니다' }, { status: 200 });

--- a/app/mocks/handlers/user-handler.mock.ts
+++ b/app/mocks/handlers/user-handler.mock.ts
@@ -66,7 +66,7 @@ export const userHandlers = [
     }
   }),
   http.get<never, never, UserInfoResponse | InitUserInfoResponse | ErrorResponseData>(
-    API_PATH.user,
+    `${API_PATH.user}/me`,
     async ({ request }) => {
       const accessToken = request.headers.get('Authorization')?.replace('Bearer ', '');
       if (accessToken === 'undefined' || !accessToken) {

--- a/app/store/querys/lecture.ts
+++ b/app/store/querys/lecture.ts
@@ -7,7 +7,7 @@ import { API_PATH } from '@/app/business/api-path';
 import { getToken } from '@/app/business/services/auth';
 import { LectureInfoResponse } from './result';
 
-export type SearchedLectureInfoResponse = LectureInfoResponse & { isTaken: boolean };
+export type SearchedLectureInfoResponse = LectureInfoResponse & { taken: boolean; revoked: boolean };
 
 export const useFetchSearchLecture = () => {
   const searchWord = useAtomValue(searchWordAtom);
@@ -20,15 +20,12 @@ export const useFetchSearchLecture = () => {
   });
 };
 
-export interface SearchLecturesResponse {
-  lectures: SearchedLectureInfoResponse[];
-}
-
 export const fetchSearchLectures = async (type: string, keyword: string) => {
-  const response = await axios<SearchLecturesResponse>(`${API_PATH.lectures}?type=${type}&&keyword=${keyword}`, {
+  const token = await getToken();
+  const response = await axios<SearchedLectureInfoResponse[]>(`${API_PATH.lectures}?type=${type}&&keyword=${keyword}`, {
     headers: {
-      Authorization: `Bearer ${getToken()}`,
+      Authorization: `Bearer ${token}`,
     },
   });
-  return response.data.lectures;
+  return response.data;
 };

--- a/app/ui/lecture/lecture-search/index.tsx
+++ b/app/ui/lecture/lecture-search/index.tsx
@@ -26,7 +26,7 @@ export default function LectureSearch() {
   const searchable = searchWord.keyword && searchWord.keyword.length > 1;
 
   return (
-    <div className="bg-white  w-full h-[500px] sm:h-[400px] z-[10] flex justify-center" data-testid="lecture-search">
+    <div className="bg-white w-full h-[520px] sm:h-[420px] z-[10] flex justify-center" data-testid="lecture-search">
       <div className="w-[800px] mx-auto my-7  flex flex-col gap-10 sm:gap-6">
         <LectureSearchBar />
         {searchable ? (

--- a/app/ui/lecture/lecture-search/lecture-search-bar.tsx
+++ b/app/ui/lecture/lecture-search/lecture-search-bar.tsx
@@ -38,7 +38,7 @@ export default function LectureSearchBar() {
           <Select.Item value="lectureCode" placeholder="과목코드" />
         </Select>
       </div>
-      <div className="w-[60%] sm:w-[40%] flex justify-between">
+      <div className="w-[60%] sm:w-[40%] flex justify-between flex-col gap-1">
         <TextInput
           data-cy="search-lecture-input"
           placeholder="검색어를 입력해주세요"
@@ -46,6 +46,7 @@ export default function LectureSearchBar() {
           onValueChange={handleDebounceKeywordSearch}
           data-testid="lecture-search-input"
         />
+        <div className="text-zinc-400 text-xs text-end">※ 회색으로 표기된 과목은 폐강과목입니다</div>
       </div>
     </div>
   );

--- a/app/ui/lecture/lecture-search/lecture-search-result.tsx
+++ b/app/ui/lecture/lecture-search/lecture-search-result.tsx
@@ -7,8 +7,8 @@ import { useFetchSearchLecture } from '@/app/store/querys/lecture';
 export default function LectureSearchResult() {
   const { data } = useFetchSearchLecture();
 
-  const renderAddActionButton = (item: SearchedLectureInfoResponse, isTaken: boolean) => {
-    return <AddTakenLectureButton lectureItem={item} isTaken={isTaken} />;
+  const renderAddActionButton = (item: SearchedLectureInfoResponse, taken: boolean) => {
+    return <AddTakenLectureButton lectureItem={item} isTaken={taken} />;
   };
 
   const render = (item: SearchedLectureInfoResponse, index: number) => {
@@ -17,11 +17,11 @@ export default function LectureSearchResult() {
       <List.Row data-cy={`lecture-${searchLectureItem.name}`} key={index}>
         <Grid cols={4}>
           {Object.keys(searchLectureItem).map((key, index) => {
-            if (key === 'id' || key === 'isTaken') return null;
+            if (key === 'id' || key === 'taken' || key === 'revoked') return null;
             return <Grid.Column key={index}>{searchLectureItem[key]}</Grid.Column>;
           })}
           {renderAddActionButton ? (
-            <Grid.Column>{renderAddActionButton(searchLectureItem, item.isTaken)}</Grid.Column>
+            <Grid.Column>{renderAddActionButton(searchLectureItem, item.taken)}</Grid.Column>
           ) : null}
         </Grid>
       </List.Row>

--- a/app/ui/lecture/lecture-search/lecture-search-result.tsx
+++ b/app/ui/lecture/lecture-search/lecture-search-result.tsx
@@ -14,7 +14,7 @@ export default function LectureSearchResult() {
   const render = (item: SearchedLectureInfoResponse, index: number) => {
     const searchLectureItem = item;
     return (
-      <List.Row data-cy={`lecture-${searchLectureItem.name}`} key={index}>
+      <List.Row data-cy={`lecture-${searchLectureItem.name}`} key={index} textColor={item.revoked ? 'gray' : 'black'}>
         <Grid cols={4}>
           {Object.keys(searchLectureItem).map((key, index) => {
             if (key === 'id' || key === 'taken' || key === 'revoked') return null;

--- a/app/ui/lecture/taken-lecture/delete-taken-lecture-button.tsx
+++ b/app/ui/lecture/taken-lecture/delete-taken-lecture-button.tsx
@@ -43,7 +43,7 @@ export default function DeleteTakenLectureButton({ lectureId, onDelete }: Delete
           >
             <Button
               label="확인"
-              className="text-primary font-bold bg-white"
+              className="text-primary font-bold bg-white hover:bg-white"
               data-cy="confirm-button"
               data-testid="confirm-button"
               onClick={() => {

--- a/app/ui/lecture/taken-lecture/delete-taken-lecture-button.tsx
+++ b/app/ui/lecture/taken-lecture/delete-taken-lecture-button.tsx
@@ -43,7 +43,7 @@ export default function DeleteTakenLectureButton({ lectureId, onDelete }: Delete
           >
             <Button
               label="확인"
-              className="font-bold"
+              className="text-primary font-bold bg-white"
               data-cy="confirm-button"
               data-testid="confirm-button"
               onClick={() => {

--- a/app/ui/user/user-info-card/user-info-content.tsx
+++ b/app/ui/user/user-info-card/user-info-content.tsx
@@ -9,7 +9,7 @@ interface UserInfoContentProps {
 }
 
 function UserInfoContent({ data }: UserInfoContentProps) {
-  const { studentNumber, studentName, completionDivision: majors, totalCredit, takenCredit, graduated } = data;
+  const { studentNumber, studentName, completeDivision: majors, totalCredit, takenCredit, graduated } = data;
 
   const percentage = getPercentage(takenCredit, totalCredit);
 

--- a/app/ui/user/user-info-navigator/user-info-navigator.tsx
+++ b/app/ui/user/user-info-navigator/user-info-navigator.tsx
@@ -26,7 +26,7 @@ function formatUserInfo(userInfo: InitUserInfoResponse | UserInfoResponse | unde
 
   return {
     name: userInfo.studentName,
-    major: userInfo.completionDivision[0].major,
+    major: userInfo.completeDivision[0].major,
     studentNumber: userInfo.studentNumber,
   };
 }

--- a/app/ui/view/molecule/list/list-row.tsx
+++ b/app/ui/view/molecule/list/list-row.tsx
@@ -3,7 +3,7 @@ import { twMerge } from 'tailwind-merge';
 
 interface ListRowProps extends React.HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
-  textColor?: 'red' | 'black';
+  textColor?: 'gray' | 'black';
 }
 
 export function ListRow({ children, textColor = 'black', ...props }: ListRowProps) {
@@ -12,7 +12,7 @@ export function ListRow({ children, textColor = 'black', ...props }: ListRowProp
       {...props}
       className={twMerge(
         'border-solid border-gray-300 border-b-[1px] last:border-b-0 py-4 font-medium text-sm xl:text-base 2xl:text-lg hover:bg-gray-100 group hover:first:rounded-t-xl hover:last:rounded-b-xl',
-        textColor === 'red' ? 'text-red-500' : 'text-zinc-700',
+        textColor === 'gray' ? 'text-zinc-400' : 'text-zinc-700',
       )}
     >
       {children}


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x] 폐강 과목 처리 및 taken lecture type 수정 ( 지난번 pr )
- [x] fetch user ( 회원 정보 조회 ) completionDivision -> completeDivision 
- [X] delete taken lecture, add taken lecture는 백엔드로부터 응답 데이터가 없는데 http Error handler에서는 응답 데이터를 꼭 넣어줘야 함 그래서 error throw를 하기에 애매해짐 하지만 이 이슈는 next fetch로 변경하면서 바뀔 부분이라고 생각되기에 동작만 되도록 코드를 수정



## 🔊 도움이 필요한 부분
아래 문제들은 next build 후 실행했을 때 발생했던 문제입니다
- 토큰이 필요한 my page나 result page 진입 시 500 에러 , 토큰이 있음에도 아예 진입 불가능했습니다
- 혹시 몰라서 middleware.ts 파일을 삭제해보니 실행이 잘되었고 middleware에서 뭔가 이슈가 있었던 것 같습니다 제가 시간이 없어서 이 부분까지 확인을 하지 못했습니다 한 번 확인부탁드립니다!
- get Token 함수가  use server 선언으로 인해 async 키워드가 필요하더라구요. 이 부분 변경했습니다
- 제가 현재 확인한 부분은 middleware을 삭제한 상태에서 build 후 my page 진입 시 my page의 user Info navigator ( 왼쪽 회원 정보 부분) 을 제외하고 모두 정상적으로 돌아가는 것을 확인했습니다 . user info navigator가 오류나는건 아니고 단지 주석했습니다
- use Suspense Query 관련한 문제가 저한텐 발생하지 않았는데 다시 한 번 확인해주실 수 있을까요?
