### PR TITLE
fix: fix my page userInfo skeleton

### DIFF
--- a/app/(sub-page)/my/page.tsx
+++ b/app/(sub-page)/my/page.tsx
@@ -7,7 +7,6 @@ import { DIALOG_KEY } from '@/app/utils/key/dialog-key.util';
 import { Suspense } from 'react';
 import MyResultContainer from './components/my-result-container';
 import SignButtonGroup from '@/app/ui/user/user-info-navigator/sign-button-group';
-import Responsive from '@/app/ui/responsive';
 import ContentContainer from '@/app/ui/view/atom/content-container/content-container';
 import TakenLectureSkeleton from '@/app/ui/lecture/taken-lecture/taken-lecture.skeleton';
 import type { Metadata } from 'next';
@@ -33,16 +32,14 @@ export default function MyPage() {
   return (
     <>
       <ContentContainer className="flex pt-10 lg:pt-16">
-        <Responsive minWidth={1023}>
-          <div className="lg:w-[30%]">
-            <Suspense fallback={<UserInfoNavigatorSkeleton />}>
-              <UserInfoNavigator />
-              <div className="mt-9">
-                <SignButtonGroup />
-              </div>
-            </Suspense>
-          </div>
-        </Responsive>
+        <div className="lg:w-[30%] lg:block hidden">
+          <Suspense fallback={<UserInfoNavigatorSkeleton />}>
+            <UserInfoNavigator />
+            <div className="mt-9">
+              <SignButtonGroup />
+            </div>
+          </Suspense>
+        </div>
         <div className="w-full lg:w-[70%] px-7 lg:px-[20px] pt-4 pb-2 flex flex-col gap-12">
           <MyResultContainer />
           <Suspense fallback={<TakenLectureSkeleton />}>


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역
close #142 

- [x] 스켈레톤 오류 수정 


## 🤔 고민 했던 부분
https://github.com/Myongji-Graduate/myongji-graduate-next/issues/142
이슈에서도 확인하실 수 있듯이 my page에서 스켈레톤이
1. table 스켈레톤이 보이고
2. userInfoNavigator 스켈레톤이 보여서
순서대로 스켈레톤이 보이기 떄문에 레이아웃이 바뀌면서 깜빡여서 해결해야겠다고 느꼈습니다.
제가 생각하기에 원인은 다음과 같습니다 ( 문서를 찾아본게 아니라 단순 제 생각이어서,, 틀렸다면 말씀해주세요!!)
- Responsive 컴포넌트가 children을 렌더링할지 여부를 결정합니다
- 서버컴포넌트인 children이 서버에서 만들어졌다하더라도
- 결국 렌더링 여부는 Responseive 클라이언트 컴포넌트로 인해 브라우저에서 결정되기 때문에, 스켈레톤이 순서대로 깜빡이는 것 같습니다

이런 경우에는 Responsive 컴포넌트 대신 classname으로 조정하는게 더 나을 것 같습니다
