### PR TITLE
Migration Fetch ax in my page

### DIFF
--- a/app/business/services/lecture/taken-lecture.command.ts
+++ b/app/business/services/lecture/taken-lecture.command.ts
@@ -1,13 +1,10 @@
 'use server';
 import { FormState } from '@/app/ui/view/molecule/form/form-root';
 import { API_PATH } from '../../api-path';
-import { httpErrorHandler } from '@/app/utils/http/http-error-handler';
 import { BadRequestError } from '@/app/utils/http/http-error';
-import { revalidateTag } from 'next/cache';
-import { TAG } from '@/app/utils/http/tag';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getToken } from '../auth';
+import { instance } from '@/app/utils/api/instance';
 
 export const registerUserGrade = async (prevState: FormState, formData: FormData) => {
   const parsingText = await parsePDFtoText(formData);
@@ -45,23 +42,13 @@ export const parsePDFtoText = async (formData: FormData) => {
 
 export const deleteTakenLecture = async (lectureId: number) => {
   try {
-    const response = await fetch(`${API_PATH.takenLectures}/${lectureId}`, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${cookies().get('accessToken')?.value}`,
-      },
+    await instance.delete(`${API_PATH.takenLectures}/${lectureId}`, {
+      responseType: 'text',
     });
-    if (response.ok) {
-      revalidateTag(TAG.GET_TAKEN_LECTURES);
-      return {
-        isSuccess: true,
-      };
-    } else {
-      return {
-        isSuccess: false,
-      };
-    }
+
+    return {
+      isSuccess: true,
+    };
   } catch (error) {
     if (error instanceof BadRequestError) {
       return {
@@ -74,30 +61,30 @@ export const deleteTakenLecture = async (lectureId: number) => {
 };
 
 export const addTakenLecture = async (lectureId: number) => {
-  const token = await getToken();
-  const response = await fetch(API_PATH.takenLectures, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ lectureId }),
-  });
-  // delete taken lecture과 비슷한 이유로 코드 수정
-  if (response.ok) {
-    revalidateTag(TAG.GET_TAKEN_LECTURES);
+  try {
+    await instance.post(
+      API_PATH.takenLectures,
+      { lectureId },
+      {
+        responseType: 'text',
+      },
+    );
     return {
       isSuccess: true,
       isFailure: false,
       validationError: {},
       message: '과목 추가에 성공했습니다',
     };
-  } else {
-    return {
-      isSuccess: false,
-      isFailure: true,
-      validationError: {},
-      message: '과목 추가에 실패했습니다',
-    };
+  } catch (error) {
+    if (error instanceof BadRequestError) {
+      return {
+        isSuccess: false,
+        isFailure: true,
+        validationError: {},
+        message: '과목 추가에 실패했습니다',
+      };
+    } else {
+      throw error;
+    }
   }
 };

--- a/app/business/services/lecture/taken-lecture.query.ts
+++ b/app/business/services/lecture/taken-lecture.query.ts
@@ -1,6 +1,5 @@
+import { instance } from '@/app/utils/api/instance';
 import { API_PATH } from '../../api-path';
-import { TAG } from '@/app/utils/http/tag';
-import { cookies } from 'next/headers';
 
 export interface TakenLecturesResponse {
   totalCredit: number;
@@ -17,13 +16,7 @@ export interface TakenLectureInfoResponse {
   credit: number;
 }
 
-export const fetchTakenLectures = async (): Promise<TakenLecturesResponse> => {
-  const response = await fetch(API_PATH.takenLectures, {
-    next: { tags: [TAG.GET_TAKEN_LECTURES] },
-    headers: {
-      Authorization: `Bearer ${cookies().get('accessToken')?.value}`,
-    },
-  });
-  const data = await response.json();
-  return data;
+export const fetchTakenLectures = async () => {
+  const response = await instance.get<TakenLecturesResponse>(API_PATH.takenLectures);
+  return response.data;
 };

--- a/app/utils/api/instance.ts
+++ b/app/utils/api/instance.ts
@@ -1,8 +1,8 @@
-import fetchAx, { FetchAxError } from 'fetch-ax';
 import { cookies } from 'next/headers';
 import { fetchAxErrorHandler } from '../http/http-error-handler';
+import fetchAX from 'fetch-ax';
 
-export const instance = fetchAx.create({
+export const instance = fetchAX.create({
   headers: {
     'Content-Type': 'application/json',
   },
@@ -11,11 +11,10 @@ export const instance = fetchAx.create({
   },
   requestInterceptor: (config) => {
     const accessToken = cookies().get('accessToken')?.value;
+
     if (accessToken) {
-      config.headers = {
-        ...config.headers,
-        Authorization: `Bearer ${accessToken}`,
-      };
+      config.headers = new Headers(config.headers);
+      config.headers?.set('Authorization', `Bearer ${accessToken}`);
     }
     return config;
   },


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x] my page에 fetch로 작업한 API를 fetch-ax로 교체했습니다
- [X] content-type이 설정이 되지 않은 오류를 해결했습니다. 

## 🤔 고민 했던 부분
- fetch-ax로 적용을 했는데 많은 line이 줄어든게 보이네요!!
- 과목 추가,과목 삭제, 과목 조회는 별다른 Custom Error가 존재하지 않기 때문에 에러 코드에 따른 분기처리는 따로 진행하지 않았습니다. 

## 🔊 도움이 필요한 부분
- fetch-ax를 사용하면서 여러 문제점들을 발견했습니다.
1. requestInterceptor에서 Headers에 설정을 했을 때 Headers가 적절히 설정이 되지 않은 오류 발생
```javascript
await instance.post(
      API_PATH.takenLectures,
      { lectureId },
      {
        responseType: 'text',
      },
``` 
위 코드와 같이 instance를 사용해서 과목 추가 api 요청을 진행했습니다. 이때 Content-Type은 instance에서 설정을 했기 때문에 별도의 설정을 하지 않았는데 요청 시 415 Error가 발생했고 확인을 해보니 instance의 requestInterceptor에 headers가 제대로 설정이 되지 않은 것을 확인했습니다.  정확한 원인을 파악하지는 못했으나, config.headers를 일반 객체가 아닌 Headers  객체로 변경이 되었을때 해결이 됐습니다. 혹시 이 원인 아시나요 ,, 
이 부분에 대해서는 responseType, Invalid URL Error 해결하면서 같이 파악해보겠습니다. 🥹
https://github.com/Myongji-Graduate/fetch-ax/issues/19