### PR TITLE
fix: api 변경에 따른 수정 작업

### DIFF
--- a/app/business/services/lecture/taken-lecture.command.ts
+++ b/app/business/services/lecture/taken-lecture.command.ts
@@ -60,7 +60,7 @@ export const deleteTakenLecture = async (lectureId: number) => {
   }
 };
 
-export const addTakenLecture = async (lectureId: number) => {
+export const addTakenLecture = async (lectureId: string) => {
   try {
     await instance.post(
       API_PATH.takenLectures,

--- a/app/mocks/data.mock.ts
+++ b/app/mocks/data.mock.ts
@@ -269,43 +269,10 @@ export const credits = JSON.parse(`[
 
 export const searchLectures = [
   {
-    id: 1,
-    lectureCode: 'KMA02106',
+    id: 'KMA02106',
     name: '영어1',
     credit: 2,
     taken: false,
     revoked: true,
-  },
-  {
-    id: 2,
-    lectureCode: 'KMA02106',
-    name: '영어2',
-    credit: 2,
-    taken: true,
-    revoked: false,
-  },
-  {
-    id: 3,
-    lectureCode: 'KMA02136',
-    name: '영어무역이론',
-    credit: 3,
-    taken: false,
-    revoked: false,
-  },
-  {
-    id: 4,
-    lectureCode: 'KMA02106',
-    name: '영어회화3',
-    credit: 1,
-    taken: false,
-    revoked: false,
-  },
-  {
-    id: 6,
-    lectureCode: 'KMA02106',
-    name: '영어회화4',
-    credit: 2,
-    taken: true,
-    revoked: false,
   },
 ];

--- a/app/mocks/db.mock.ts
+++ b/app/mocks/db.mock.ts
@@ -26,7 +26,7 @@ type MockDatabaseAction = {
   reset: () => void;
   getTakenLectures: () => TakenLecturesResponse;
   getSearchLectures: () => SearchedLectureInfoResponse[];
-  addTakenLecture: (lectureId: number) => boolean;
+  addTakenLecture: (lectureId: string) => boolean;
   deleteTakenLecture: (lectureId: number) => boolean;
   createUser: (user: SignUpRequestBody) => boolean;
   signIn: (userData: SignInRequestBody) => boolean;
@@ -70,10 +70,10 @@ export const mockDatabase: MockDatabaseAction = {
     mockDatabaseStore.takenLectures.takenLectures = [
       ...mockDatabaseStore.takenLectures.takenLectures,
       {
-        id: lectureId,
+        id: 141,
+        lectureCode: 'KMA02106',
         year: '2023',
         semester: '2학기',
-        lectureCode: lecture.lectureCode,
         lectureName: lecture.name,
         credit: lecture.credit,
       },

--- a/app/mocks/handlers/taken-lecture-handler.mock.ts
+++ b/app/mocks/handlers/taken-lecture-handler.mock.ts
@@ -14,9 +14,9 @@ export const takenLectureHandlers = [
     await delay(100);
     return HttpResponse.json(takenLectures);
   }),
-  http.post<never, { lectureId: number }>(API_PATH.takenLectures, async ({ request }) => {
+  http.post<never, { lectureCode: string }>(API_PATH.takenLectures, async ({ request }) => {
     const body = await request.json();
-    const isAdded = mockDatabase.addTakenLecture(body.lectureId);
+    const isAdded = mockDatabase.addTakenLecture(body.lectureCode);
     await delay(1000);
     if (isAdded) return HttpResponse.json({ message: '과목 추가에 성공했습니다' }, { status: 200 });
     return HttpResponse.json({ errorCode: 400, message: '추가에 실패했습니다' }, { status: 400 });

--- a/app/store/querys/result.ts
+++ b/app/store/querys/result.ts
@@ -7,8 +7,7 @@ import axios from 'axios';
 
 export interface LectureInfoResponse {
   [index: string]: string | number | boolean;
-  id: number;
-  lectureCode: string;
+  id: string;
   name: string;
   credit: number;
 }

--- a/app/ui/lecture/lecture-search/lecture-search-result.tsx
+++ b/app/ui/lecture/lecture-search/lecture-search-result.tsx
@@ -30,7 +30,7 @@ export default function LectureSearchResult() {
       <List.Row data-cy={`lecture-${searchLectureItem.name}`} key={index} textColor={item.revoked ? 'gray' : 'black'}>
         <Grid cols={4}>
           {Object.keys(searchLectureItem).map((key, index) => {
-            if (key === 'id' || key === 'taken' || key === 'revoked') return null;
+            if (key === 'taken' || key === 'revoked') return null;
             return <Grid.Column key={index}>{searchLectureItem[key]}</Grid.Column>;
           })}
           {renderAddActionButton ? (

--- a/app/ui/result/result-category-detail-lecture/result-cagegory-detail-lecture.tsx
+++ b/app/ui/result/result-category-detail-lecture/result-cagegory-detail-lecture.tsx
@@ -46,6 +46,7 @@ function ResultCagegoryDetailLecture({ detailCategory, isTakenLecture }: ResultC
           headerInfo={headerInfo}
           data={isTakenLecture ? takenLectures : haveToLectures}
           emptyDataRender={emptyDataRender}
+          nonRenderableKey={[]}
         />
       )}
     </div>

--- a/app/ui/result/result-category-detail/result-category-detail-info.tsx
+++ b/app/ui/result/result-category-detail/result-category-detail-info.tsx
@@ -1,7 +1,6 @@
 import ResultCategoryDetailContent from '@/app/ui/result/result-category-detail-content/result-category-detail-content';
 import {
   CreditResponse,
-  LectureInfoResponse,
   ResultCategoryDetailLecturesResponse,
   useFetchCredits,
   useFetchResultCategoryDetailInfo,
@@ -13,7 +12,7 @@ const CHAPEL_TOTAL_CREDIT = 2.0;
 const CHAPEL_TOTAL_COUNT = 4;
 const CHAPEL_CREDIT = CHAPEL_TOTAL_CREDIT / CHAPEL_TOTAL_COUNT;
 
-const CHAPEL_LECTURE_INFO: LectureInfoResponse = {
+const CHAPEL_LECTURE_INFO = {
   id: 0,
   lectureCode: 'KMA02101',
   name: '채플',

--- a/app/ui/view/molecule/list/list-root.tsx
+++ b/app/ui/view/molecule/list/list-root.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/app/utils/shadcn/utils';
 import { ReactNode } from 'react';
 
 export interface ListRow {
-  id: number;
+  id: number | string;
   [key: string]: string | number | boolean;
 }
 export interface ListRootProps<T extends ListRow> {

--- a/app/ui/view/molecule/table/index.tsx
+++ b/app/ui/view/molecule/table/index.tsx
@@ -12,6 +12,7 @@ interface TableProps<T extends ListRow> {
   renderActionButton?: (item: T) => JSX.Element;
   swipeable?: boolean;
   emptyDataRender?: () => ReactNode;
+  nonRenderableKey?: string[]; // 테이블에 렌더링 하지 않을 키 값
 }
 
 interface SwipeableTableProps<T extends ListRow> extends TableProps<T> {
@@ -38,6 +39,7 @@ export function Table<T extends ListRow>({
   swipeable = false,
   onSwipeAction,
   emptyDataRender,
+  nonRenderableKey = ['id'],
 }: SwipeableTableProps<T> | BasicTableProps<T>) {
   const cols = renderActionButton && !swipeable ? 'render-button' : headerInfo.length;
 
@@ -46,7 +48,7 @@ export function Table<T extends ListRow>({
       <List.Row key={index}>
         <Grid cols={isCol(cols) ? cols : 6}>
           {Object.keys(item).map((key, index) => {
-            if (key === 'id') return null;
+            if (nonRenderableKey.includes(key)) return null;
             return <Grid.Column key={index}>{item[key]}</Grid.Column>;
           })}
           {renderActionButton ? <Grid.Column>{renderActionButton(item)}</Grid.Column> : null}

--- a/app/utils/api/instance.ts
+++ b/app/utils/api/instance.ts
@@ -13,8 +13,10 @@ export const instance = fetchAX.create({
     const accessToken = cookies().get('accessToken')?.value;
 
     if (accessToken) {
-      config.headers = new Headers(config.headers);
-      config.headers?.set('Authorization', `Bearer ${accessToken}`);
+      config.headers = {
+        ...config.headers,
+        Authorization: `Bearer ${accessToken}`,
+      };
     }
     return config;
   },

--- a/app/utils/global/cypress-provider.tsx
+++ b/app/utils/global/cypress-provider.tsx
@@ -6,8 +6,8 @@ import { useEffect } from 'react';
 export function CypressProvider({ children }: React.PropsWithChildren) {
   useEffect(() => {
     if (window.Cypress) {
-      window.addTakenLecture = async (lectureId: number[]) => {
-        await Promise.all(lectureId.map((id) => addTakenLecture(id)));
+      window.addTakenLecture = async (lectureCode: string[]) => {
+        await Promise.all(lectureCode.map((id) => addTakenLecture(id)));
       };
 
       window.resetMockDB = async () => {
@@ -21,7 +21,7 @@ export function CypressProvider({ children }: React.PropsWithChildren) {
 
 declare global {
   interface Window {
-    addTakenLecture: (lectureId: number[]) => Promise<void>;
+    addTakenLecture: (lectureCode: string[]) => Promise<void>;
     resetMockDB: () => Promise<void>;
   }
 }


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

closed #161 

> 구현 내용 및 작업 했던 내역

- [x] api 변경에 따른 수정 작업
- [x] table nonrenderable key 추가 

## 🤔 고민 했던 부분
- 서버에서 과목 검색과 과목 상세에서 id가 정수형이 아닌 과목 코드로 변경이 되었고 이에 따른 타입 수정을 진행하였습니다
- 또한 기존에는 id가 정수형이기에 Table 공통 컴포넌트에서 id면 렌더링하지 않도록 처리해주었습니다 하지만 수정 이후 마이페이지 기이수 과목 리스트에선 id가 정수형이어서 렌더링되지 않아야하지만, `ResultCagegoryDetailLecture`에서는 id가 과목 코드이므로 노출이 필요했습니다 
- 그래서 nonRenderableKey라는 속성을 통해 Table 컴포넌트를 사용하는 곳에서 자유롭게 처리하도록 수정했습니다 
