### PR TITLE
fix: 사이드바 수정

### DIFF
--- a/app/(sub-page)/components/navigation-bar.tsx
+++ b/app/(sub-page)/components/navigation-bar.tsx
@@ -3,7 +3,6 @@ import logo from '../../../public/assets/logo.svg';
 import Responsive from '../../ui/responsive';
 import SideNavigationBar from './side-navigation-bar';
 import UserInfoNavigator from '@/app/ui/user/user-info-navigator/user-info-navigator';
-import SignButtonGroup from '@/app/ui/user/user-info-navigator/sign-button-group';
 import Link from 'next/link';
 import NavigationItems from './navigation-items';
 import UserDeleteModal from '@/app/ui/user/user-info-navigator/user-delete-modal';

--- a/app/(sub-page)/components/navigation-bar.tsx
+++ b/app/(sub-page)/components/navigation-bar.tsx
@@ -7,15 +7,23 @@ import SignButtonGroup from '@/app/ui/user/user-info-navigator/sign-button-group
 import Link from 'next/link';
 import NavigationItems from './navigation-items';
 import UserDeleteModal from '@/app/ui/user/user-info-navigator/user-delete-modal';
+import { auth } from '@/app/business/services/user/user.query';
+import UserDeleteButton from '@/app/ui/user/user-info-navigator/user-delete-button';
 
-export default function NavigationBar() {
+export default async function NavigationBar() {
+  const userInfo = auth();
+
   return (
     <div className="absolute flex justify-between items-center p-2.5 border-b-[1px] w-full z-2">
       <Link href={'/'}>
         <Image className="md:h-10 h-7 w-[110px] md:w-[150px]" width={150} height={100} src={logo} alt="main-logo" />
       </Link>
       <Responsive maxWidth={1023}>
-        <SideNavigationBar header={<UserInfoNavigator />} content={<NavigationItems />} footer={<SignButtonGroup />} />
+        <SideNavigationBar
+          header={<UserInfoNavigator />}
+          content={<NavigationItems />}
+          footer={(await userInfo) ? <UserDeleteButton /> : <></>}
+        />
       </Responsive>
       <Responsive minWidth={1024}>
         <NavigationItems />

--- a/app/(sub-page)/components/navigation-bar.tsx
+++ b/app/(sub-page)/components/navigation-bar.tsx
@@ -11,7 +11,7 @@ import { auth } from '@/app/business/services/user/user.query';
 import UserDeleteButton from '@/app/ui/user/user-info-navigator/user-delete-button';
 
 export default async function NavigationBar() {
-  const userInfo = auth();
+  const userInfo = await auth();
 
   return (
     <div className="absolute flex justify-between items-center p-2.5 border-b-[1px] w-full z-2">
@@ -22,7 +22,7 @@ export default async function NavigationBar() {
         <SideNavigationBar
           header={<UserInfoNavigator />}
           content={<NavigationItems />}
-          footer={(await userInfo) ? <UserDeleteButton /> : <></>}
+          footer={userInfo ? <UserDeleteButton /> : <></>}
         />
       </Responsive>
       <Responsive minWidth={1024}>

--- a/app/(sub-page)/components/navigation-items.tsx
+++ b/app/(sub-page)/components/navigation-items.tsx
@@ -38,30 +38,21 @@ interface NavigationItemProps {
 }
 
 export function NavigationItem({ href, label, target }: NavigationItemProps) {
-  if (label === '로그아웃') {
-    return (
-      <form action={signOut}>
-        <Button
-          type="submit"
-          size={'xs'}
-          className="text-black w-full lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg justify-start"
-          variant={'text'}
-          label={label}
-        >
-          {label}
-        </Button>
-      </form>
-    );
-  }
+  const isLogout = label === '로그아웃';
+  const button = (
+    <Button
+      size={'xs'}
+      className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg "
+      variant={'text'}
+      label={label}
+    />
+  );
 
-  return (
+  return isLogout ? (
+    <form action={signOut}>{button}</form>
+  ) : (
     <Link href={href} target={target} className="flex items-center justify-between">
-      <Button
-        size={'xs'}
-        className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg "
-        variant={'text'}
-        label={label}
-      />
+      {button}
       <ChevronRightIcon className="h-4 w-4 lg:hidden text-black" />
     </Link>
   );

--- a/app/(sub-page)/components/navigation-items.tsx
+++ b/app/(sub-page)/components/navigation-items.tsx
@@ -44,7 +44,7 @@ export function NavigationItem({ href, label, target }: NavigationItemProps) {
         <Button
           type="submit"
           size={'xs'}
-          className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-md "
+          className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg "
           variant={'text'}
           label={label}
         >
@@ -58,7 +58,7 @@ export function NavigationItem({ href, label, target }: NavigationItemProps) {
     <Link href={href} target={target} className="flex items-center justify-between">
       <Button
         size={'xs'}
-        className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-md "
+        className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg "
         variant={'text'}
         label={label}
       />

--- a/app/(sub-page)/components/navigation-items.tsx
+++ b/app/(sub-page)/components/navigation-items.tsx
@@ -44,7 +44,7 @@ export function NavigationItem({ href, label, target }: NavigationItemProps) {
         <Button
           type="submit"
           size={'xs'}
-          className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg "
+          className="text-black w-full lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg justify-start"
           variant={'text'}
           label={label}
         >

--- a/app/(sub-page)/components/navigation-items.tsx
+++ b/app/(sub-page)/components/navigation-items.tsx
@@ -44,7 +44,7 @@ export function NavigationItem({ href, label, target }: NavigationItemProps) {
         <Button
           type="submit"
           size={'xs'}
-          className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg "
+          className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-md "
           variant={'text'}
           label={label}
         >
@@ -58,7 +58,7 @@ export function NavigationItem({ href, label, target }: NavigationItemProps) {
     <Link href={href} target={target} className="flex items-center justify-between">
       <Button
         size={'xs'}
-        className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg "
+        className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-md "
         variant={'text'}
         label={label}
       />

--- a/app/(sub-page)/components/navigation-items.tsx
+++ b/app/(sub-page)/components/navigation-items.tsx
@@ -2,6 +2,7 @@ import { auth } from '@/app/business/services/user/user.query';
 import Button from '@/app/ui/view/atom/button/button';
 import Link from 'next/link';
 import { ChevronRightIcon } from 'lucide-react';
+import { signOut } from '@/app/business/services/user/user.command';
 
 export default async function NavigationItems() {
   const userInfo = await auth();
@@ -10,6 +11,7 @@ export default async function NavigationItems() {
     <div className="flex flex-col lg:flex-row divide-y lg:divide-y-0 ">
       {userInfo ? (
         <>
+          <NavigationItem href={'/sign-in'} label="로그아웃" />
           <NavigationItem href={'/my'} label="마이페이지" />
           <NavigationItem href={'/result'} label="결과확인" />
         </>
@@ -36,6 +38,22 @@ interface NavigationItemProps {
 }
 
 export function NavigationItem({ href, label, target }: NavigationItemProps) {
+  if (label === '로그아웃') {
+    return (
+      <form action={signOut}>
+        <Button
+          type="submit"
+          size={'xs'}
+          className="text-black lg:text-white hover:text-slate-400 py-5 lg:text-base text-lg "
+          variant={'text'}
+          label={label}
+        >
+          {label}
+        </Button>
+      </form>
+    );
+  }
+
   return (
     <Link href={href} target={target} className="flex items-center justify-between">
       <Button

--- a/app/(sub-page)/components/side-navigation-bar.tsx
+++ b/app/(sub-page)/components/side-navigation-bar.tsx
@@ -30,7 +30,9 @@ export default function SideNavigationBar({ header, content, footer }: SideNavig
         <div className="flex h-full flex-col justify-between">
           <SheetHeader>{header}</SheetHeader>
           <div className="w-full h-1 rounded-full my-4 bg-gray-200" />
-          <div className="h-full">{content}</div>
+          <div className="h-full" onClick={() => close()}>
+            {content}
+          </div>
           <SheetFooter>{footer}</SheetFooter>
         </div>
       </SheetContent>

--- a/app/(sub-page)/components/side-navigation-bar.tsx
+++ b/app/(sub-page)/components/side-navigation-bar.tsx
@@ -29,7 +29,6 @@ export default function SideNavigationBar({ header, content, footer }: SideNavig
       <SheetContent className="z-3">
         <div className="flex h-full flex-col justify-between">
           <SheetHeader>{header}</SheetHeader>
-          <div className="w-full h-1 rounded-full my-4 bg-gray-200" />
           <div className="h-full" onClick={() => close()}>
             {content}
           </div>

--- a/app/ui/user/user-info-navigator/sign-out-button.tsx
+++ b/app/ui/user/user-info-navigator/sign-out-button.tsx
@@ -1,10 +1,15 @@
 'use client';
 import { signOut } from '@/app/business/services/user/user.command';
 import Button from '../../view/atom/button/button';
+import { DIALOG_KEY } from '@/app/utils/key/dialog-key.util';
+import useDialog from '@/app/hooks/useDialog';
 
 export default function SignOutButton() {
+  const { close } = useDialog(DIALOG_KEY.SIDE_NAVIGATION);
+
   const handleSignOut = async () => {
     await signOut();
+    close();
   };
 
   return <Button onClick={handleSignOut} size="sm" variant="secondary" label="로그아웃" />;

--- a/app/ui/user/user-info-navigator/sign-out-button.tsx
+++ b/app/ui/user/user-info-navigator/sign-out-button.tsx
@@ -1,15 +1,10 @@
 'use client';
 import { signOut } from '@/app/business/services/user/user.command';
 import Button from '../../view/atom/button/button';
-import { DIALOG_KEY } from '@/app/utils/key/dialog-key.util';
-import useDialog from '@/app/hooks/useDialog';
 
 export default function SignOutButton() {
-  const { close } = useDialog(DIALOG_KEY.SIDE_NAVIGATION);
-
   const handleSignOut = async () => {
     await signOut();
-    close();
   };
 
   return <Button onClick={handleSignOut} size="sm" variant="secondary" label="로그아웃" />;

--- a/app/ui/user/user-info-navigator/user-info-navigator.tsx
+++ b/app/ui/user/user-info-navigator/user-info-navigator.tsx
@@ -35,7 +35,7 @@ export default async function UserInfoNavigator() {
   const userInfo = formatUserInfo(await auth());
 
   return (
-    <div className="flex md:flex-col items-center md:p-4 space-x-4 md:space-x-0">
+    <div className="flex md:flex-col items-center md:p-4 bo border-b-4 md:border-b-0 pb-6 space-x-4 md:space-x-0">
       <Avatar className="w-16 h-16 md:w-24 md:h-24" alt="Profile picture" src={'/assets/profile-image.png'} />
       <div className="flex flex-col items-start md:items-center">
         <div className="md:my-5 md:text-lg ">

--- a/app/ui/user/user-info-navigator/user-info-navigator.tsx
+++ b/app/ui/user/user-info-navigator/user-info-navigator.tsx
@@ -35,7 +35,7 @@ export default async function UserInfoNavigator() {
   const userInfo = formatUserInfo(await auth());
 
   return (
-    <div className="flex md:flex-col items-center md:p-4 bo border-b-4 md:border-b-0 pb-6 space-x-4 md:space-x-0">
+    <div className="flex md:flex-col items-center md:p-4 border-b-4 md:border-b-0 pb-6 space-x-4 md:space-x-0">
       <Avatar className="w-16 h-16 md:w-24 md:h-24" alt="Profile picture" src={'/assets/profile-image.png'} />
       <div className="flex flex-col items-start md:items-center">
         <div className="md:my-5 md:text-lg ">


### PR DESCRIPTION
## **📌** 작업 내용

close #177 

---

1. 페이지 이동 후 사이드바가 열려있었던 버그 수정

**[수정전]**

https://github.com/user-attachments/assets/5b92b635-0388-4a39-ab5f-7beb5a8a7ba9

<br/>

**[수정후]**

https://github.com/user-attachments/assets/fd42827b-ca10-4ec3-a708-3368cc293966

<br/>
<br/>

2. 헤더에 로그아웃 버튼 추가 및 사이드바 수정

**[수정전 - 로그인 되어있는 상태 헤더]**
<img width="1470" height="797" alt="스크린샷 2025-08-06 오후 5 42 54" src="https://github.com/user-attachments/assets/330c970a-c24a-42b9-b7b3-219856baa27e" />

<br/>
<br/>

**[수정 후 - 로그인 되어있는 상태 헤더]**
<img width="1470" height="797" alt="스크린샷 2025-08-06 오후 5 43 01" src="https://github.com/user-attachments/assets/39ff97af-4b5d-4159-bdf7-5fe27caac595" />

(원래 버전에서도 로그아웃 상태일 때에는 로그인 버튼이 헤더 및 사이드바에 포함되어있습니다!)

---

**[수정 전 - 로그인 되어있는 상태 사이드바]**
(사이드바가 반응형이 되어있어서 사진 각각 두 개 첨부해두었습니다.)

<img width="687" height="710" alt="스크린샷 2025-08-06 오후 6 18 00" src="https://github.com/user-attachments/assets/e2c0fd90-94a3-44b6-8f64-734d29a71614" />
<img width="823" height="714" alt="스크린샷 2025-08-06 오후 6 18 15" src="https://github.com/user-attachments/assets/711ae8ea-23d4-43d1-84d6-8e15ddbc42b0" />

+로그아웃 같은 경우는 다른 버튼들과 달리 페이지를 이동하는 기능이 아니기 때문에 리스트의 오른쪽에 > 아이콘이 존재하지 않습니다.


<br/>
<br/>

**[수정 후 - 로그인 되어있는 상태 사이드바] -> 배포 사이즈에서는 글자 크기가 로컬에서보다 작게 보여서 비율이 사진보다 더 깔끔할 것 같아요**
<img width="848" height="714" alt="스크린샷 2025-08-06 오후 5 43 37" src="https://github.com/user-attachments/assets/fc3bb37a-48a1-4906-9cff-c6a9db9e6423" />
<img width="802" height="714" alt="스크린샷 2025-08-06 오후 5 43 53" src="https://github.com/user-attachments/assets/3b3da356-5877-4539-a3b1-686fa695dcee" />

---

**[수정 전 - 로그아웃 되어있는 상태 사이드 바] -> 로그인 버튼이 불필요하게 위/아래 두 개 보이게 됨**
<img width="729" height="716" alt="스크린샷 2025-08-06 오후 5 45 06" src="https://github.com/user-attachments/assets/4cdf8389-f6bb-4c2e-8062-cde0f23f344b" />

<img width="811" height="712" alt="스크린샷 2025-08-06 오후 5 44 44" src="https://github.com/user-attachments/assets/0712fd01-8a93-4573-b3df-d6f11e49171d" />

<br/>
<br/>

**[수정 후 - 로그아웃 되어있는 상태 사이드바] -> 로그인 버튼을 보이지 않게 수정**
<img width="809" height="715" alt="스크린샷 2025-08-06 오후 5 44 31" src="https://github.com/user-attachments/assets/0f767de4-a40f-4876-a2e1-4ca31b351a2f" />
<img width="880" height="715" alt="스크린샷 2025-08-06 오후 5 44 15" src="https://github.com/user-attachments/assets/b23adc98-9954-4b9a-ac00-68a93ddb99c3" />


> 구현 내용 및 작업 했던 내역

- [x] 사이드바가 페이지 이동을 한 후에도 여전히 열려있었기 때문에 이를 수정했습니다.
- [x] 저번에 말씀 나눴던 대로 로그아웃 버튼을 헤더에 추가하고, 이와 관련해 사이드바쪽도 함께 수정했습니다.

## 🔊 도움이 필요한 부분
-  나중에 코드 보시면 아시겠지만 사이드바랑 헤더랑 연결점이 많더라구요! navigation 관련 등등... 그래서 제가 바꾼 코드들에 대해 이상한점이 없는지 확인해주시면 좋을 것 같습니다
