### PR TITLE
style: 비회원검사 레이아웃 수정

### DIFF
--- a/app/(sub-page)/anonymous/result/component/anonymous-result.tsx
+++ b/app/(sub-page)/anonymous/result/component/anonymous-result.tsx
@@ -25,7 +25,7 @@ const AnonymousResult = ({ category }: AnonymousResultProp) => {
       <div className="w-full">
         <UserInfoContentViewer data={parseUserInfo(result)} categories={parseCredit(result)} />
       </div>
-      <ResultCategoryViewer categories={parseCredit(result)} className="top-[20rem] md:top-[27rem]" />
+      <ResultCategoryViewer categories={parseCredit(result)} className="top-[27rem] md:top-[35rem]" />
       {category ? (
         <ResultCategoryDetailDialog querystring={category}>
           <ResultCategoryDetailInfoViewer


### PR DESCRIPTION
## **📌** 작업 내용
close #189

[수정 전]
<img width="1470" height="800" alt="스크린샷 2025-08-14 오후 9 29 30" src="https://github.com/user-attachments/assets/2a55d0a2-ee11-420f-a3e7-ef3f3fb41c55" />

[수정 후]
<img width="1469" height="798" alt="스크린샷 2025-08-14 오후 9 28 53" src="https://github.com/user-attachments/assets/bc78634b-02d1-43aa-adcb-8af11573373b" />

> 구현 내용 및 작업 했던 내역

- [x] 비회원 검사 페이지 레이아웃도 수정했습니다!

## 🤔 고민 했던 부분
- 이전에 레이아웃 짤리는 거 수정할 때 여기는 확인을 못했었는데 컴포넌트 구조가 당연히 동일하다고 생각하고 신경을 안썼는데 다른 것 같아요😅
