### PR TITLE
style: 마이페이지 성적표 재업로드 버튼 수정

### DIFF
--- a/app/ui/lecture/taken-lecture/taken-lecture-label.tsx
+++ b/app/ui/lecture/taken-lecture/taken-lecture-label.tsx
@@ -24,13 +24,7 @@ export default function TakenLectureLabel() {
             onClick={open}
           />
           <Link tabIndex={isOpen ? -1 : 0} href="/grade-upload">
-            <Button
-              tabIndex={isOpen ? -1 : 0}
-              className="max-lg:text-xs"
-              label="성적표 재업로드"
-              variant="secondary"
-              size="xs"
-            />
+            <Button tabIndex={isOpen ? -1 : 0} label="성적표 재업로드" variant="secondary" size="xs" />
           </Link>
         </div>
       }


### PR DESCRIPTION
## **📌** 작업 내용

close #195 

[수정 전] -> 창이 작아지면 `성적표 재업로드` 버튼 사이즈가 줄어듦
<img width="489" height="482" alt="image" src="https://github.com/user-attachments/assets/286f8a87-0ca2-4145-8922-7bce1944d5b3" />

[수정 후]
<img width="494" height="480" alt="image" src="https://github.com/user-attachments/assets/4f121935-4071-4692-b477-b91d608bbe70" />



> 구현 내용 및 작업 했던 내역

- [x] 불필요한 스타일링 코드 제거
