### PR TITLE
fix: 결과 페이지 버그

### DIFF
--- a/app/ui/result/result-category-detail/result-category-detail-info.tsx
+++ b/app/ui/result/result-category-detail/result-category-detail-info.tsx
@@ -14,8 +14,7 @@ const CHAPEL_TOTAL_COUNT = 4;
 const CHAPEL_CREDIT = CHAPEL_TOTAL_CREDIT / CHAPEL_TOTAL_COUNT;
 
 const CHAPEL_LECTURE_INFO = {
-  id: 0,
-  lectureCode: 'KMA02101',
+  id: 'KMA02101',
   name: '채플',
   credit: CHAPEL_CREDIT,
 };


### PR DESCRIPTION
## **📌** 작업 내용

- [x] 결과 페이지 버그 해결 

## 🤔 고민 했던 부분
로그를 찍어보니 채플만 데이터 형식이 다르게 들어오더군요@@
서버에서 채플은 다른 과목과 차이가 있는지 따로 내려주지 않아서, 채플을 수강했을 경우 그냥 수강 과목에 추가되는 방식으로 구현돼 있었습니다
-> 그래서 초기 데이터를 수정해두었습니다!


<img width="359" height="202" alt="스크린샷 2025-08-22 오전 12 50 34" src="https://github.com/user-attachments/assets/89876a9d-b764-44b4-8a4f-4afb9c87b57a" />
<img width="1163" height="356" alt="스크린샷 2025-08-22 오전 12 50 46" src="https://github.com/user-attachments/assets/b4224407-ab92-480f-b03f-3145322a7248" />


## 🔊 도움이 필요한 부분
- msw 작동안하고 다른 채플이 보이는 부분에서도 잘 보이는지 확인부탁드립니다! 
