### PR TITLE
fix: initUser일 때 버그 해결

### DIFF
--- a/app/business/services/user/user.command.ts
+++ b/app/business/services/user/user.command.ts
@@ -18,6 +18,7 @@ import {
   ValidateTokenResponseSchema,
   ResetPasswordFormSchema,
   isExpiredGradeUser,
+  isInitUser,
 } from './user.validation';
 import { cookies } from 'next/headers';
 import { isValidation } from '@/app/utils/zod/validation.util';
@@ -136,6 +137,11 @@ export async function authenticate(prevState: FormState, formData: FormData): Pr
       message: '재업로드',
     };
   }
+
+  if (isInitUser(user)) {
+    redirect('/grade-upload');
+  }
+
   redirect('/my');
   return {
     isSuccess: true,


### PR DESCRIPTION
## **📌** 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 회원가입 후 처음 성적표 입력 동작 안하는 버그 해결
- [x] 회원가입 후 상단 네비게이션 바의 로그아웃 버튼 동작 안하는 버그 해결

## 🤔 고민 했던 부분
**상황 정리**
	1. 회원가입 -> 로그인 후 redirect('/my') 실행 -> URL은 /my 로 바뀜
	2. middleware 안의 getAuth는 auth()에서 반환된 user가 init 상태(성적표 입력x) 라서 실제로 /grade-upload로 보내야 함.
	3. 결과:
	     URL은 /my 인데 화면은 grade-upload 페이지 컴포넌트가 이미 렌더링됨 => hydration 불일치라서 버튼 클릭, 네비게이션 같은 클라이언트 이벤트 먹통
	4. 새로고침하면 → middleware가 정상 실행되고 URL이 /grade-upload로 바뀌면서 동작이 정상화

이래가지구 안됐던거였습니다!!!!!!!!! 우하하하하.
저는 잘 동작하는데 확인 부탁드립니담.. 

(확실하게 하기 위해,,! - 성적표 입력 시 Something went wrong과는 또 다른 버그인 것 같다고 생각합니담)
