### PR TITLE
refactor: 에러메시지 통일

### DIFF
--- a/app/utils/api/constant.ts
+++ b/app/utils/api/constant.ts
@@ -1,23 +1,23 @@
 export const ERROR_CODE = {
   // USER
-  UNREGISTERED_USER: '',
-  INVALIDATED_STUDENT_NUMBER_TYPE: '',
-  INVALIDATED_PASSWORD_TPYE: '',
-  MISMATCHED_PASSWORD: '',
-  NOT_FOUND_AUTHID: '',
-  INVALIDATED_AUTHID_TYPE: '',
-  INCORRECT_PASSWORD: '',
-  DUPLICATED_STUDENT_NUMBER: '',
-  DUPLICATED_AUTHID: '',
-  UNSUPPORTED_STUDENT_NUMBER: '',
-  INVALIDATED_AUTH_TOKEN: '',
+  UNREGISTERED_USER: '등록되지 않은 사용자입니다.',
+  INVALIDATED_STUDENT_NUMBER_TYPE: '잘못된 형식의 학번입니다.',
+  INVALIDATED_PASSWORD_TYPE: '잘못된 형식의 비밀번호입니다.',
+  MISMATCHED_PASSWORD: '비밀번호가 일치하지 않습니다.',
+  NOT_FOUND_AUTHID: '존재하지 않는 아이디입니다.',
+  INVALIDATED_AUTHID_TYPE: '잘못된 형식의 아이디입니다.',
+  INCORRECT_PASSWORD: '비밀번호가 올바르지 않습니다.',
+  DUPLICATED_STUDENT_NUMBER: '이미 등록된 학번입니다.',
+  DUPLICATED_AUTHID: '이미 사용 중인 아이디입니다.',
+  UNSUPPORTED_STUDENT_NUMBER: '지원하지 않는 학번입니다.',
+  INVALIDATED_AUTH_TOKEN: '유효하지 않은 인증 토큰입니다. 다시 로그인해주세요.',
 
   // COMMON
   INTERNAL_SEVER_ERROR: '예상치 못한 에러가 발생했습니다.',
 
   // RESULT
-  INVALIDATED_GRADUATION_CATEGORY: '',
-  UNFITTED_GRADUATION_CATEGORY: '',
+  INVALIDATED_GRADUATION_CATEGORY: '올바르지 않은 졸업 요건 구분입니다.',
+  UNFITTED_GRADUATION_CATEGORY: '졸업 요건에 부합하지 않습니다.',
 
   // LECTURE (아래 세개 모두 PDF Parsing에서 발생하는 에러)
   INCORRECT_STUDENT_NUMBER: '학번과 일치하는 성적PDF를 입력해주세요.',

--- a/app/utils/http/http-error-handler.ts
+++ b/app/utils/http/http-error-handler.ts
@@ -8,6 +8,7 @@ import {
   InternetServerError,
 } from './http-error';
 import { FetchAxError } from 'fetch-ax';
+import { ERROR_CODE } from '../api/constant';
 
 export interface ErrorResponseData {
   status: number;
@@ -62,7 +63,8 @@ interface ErrorData {
 
 export const fetchAxErrorHandler = (error: FetchAxError<ErrorData>) => {
   const status = error.statusCode;
-  const message = error.response.data.errorCode; // 여기서 errorcode를 message로 변환 필요
+  const errorCode = error.response.data.errorCode;
+  const message = errorCode in ERROR_CODE ? ERROR_CODE[errorCode as keyof typeof ERROR_CODE] : errorCode;
   const response = error.response;
 
   switch (status) {


### PR DESCRIPTION
## **📌** 작업 내용

close #207 

> 구현 내용 및 작업 했던 내역

<img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/b8a68063-fb74-4abc-8354-961a65ac8b08" />

- [x] error code constants에 한국어 메시지 추가
  - 혹시 누락된 error code가 있을까 싶어 백엔드쪽 코드 보면서 이상없는 점 체크했습니다!
  - 에러코드 중 TPYE -> TYPE 오타 수정했습니다.
- [x] fetchAxErrorHandler에서 에러메시지 변환 코드 추가

## 🤔 고민 했던 부분
- 같은 기능을 하는 httpErrorHandler가 있긴 한데 ProtectedPage(현재 사용하지 않는 페이지로 추정됩니다,,! 아마두..)에서만 사용하고 있었구, 현재 api에는 fetchAxErrorHandler를 사용하는 것 같아 일단 해당 부분만 수정했습니다.