### PR TITLE
chore:  exitOnceUploaded: true 옵션추가

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,11 +24,12 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Publish to Chromatic
+      - name: Publish to Chromatic (upload only)
         id: chromatic
         uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitOnceUploaded: true
 
       - name: comment PR
         uses: thollander/actions-comment-pull-request@v1


### PR DESCRIPTION
## **📌** 작업 내용

Chromatic 액션이 
스토리북 빌드 업로드 → UI Tests(비주얼 회귀 테스트) 실행 → UI Review(승인 프로세스) 대기의 세 단계를 거친다고합니다! `exitOnceUploaded: true `로 스토리북 업로드까지만 실행하고 UI Tests와 UI Review 단계를 기다리지 않고 스킵하게 된다고 하네용

> 구현 내용 및 작업 했던 내역

- [x]  exitOnceUploaded: true 옵션추가



## 🤔 고민 했던 부분

> - Chromatic 사이트에서 설정으로도 변경 가능하다고 하는데 yml설정으로도 제어 가능한거 같아서 적용하였습니다!
> 혹여 이 부분이 적용되지 않는다면 Chromatic 권한이 있으신 분께 ui테스트 disabled 설정 요청드려야 할 거 같습니다!

-> ui테스트에서 실패해서  Chromatic설정에 들어가니 저도 권한이 있더라구요! 그래서 껐씁니다 해당 피알은 닫겠습니다... !! 하하

## 🔊 도움이 필요한 부분

