### PR TITLE
refactor: user-info-navigator 깨짐 해결

### DIFF
--- a/app/(sub-page)/my/page.tsx
+++ b/app/(sub-page)/my/page.tsx
@@ -35,7 +35,7 @@ export default function MyPage() {
       <ContentContainer className="flex pt-10 lg:pt-16">
         <div className="lg:w-[30%] lg:block hidden">
           <Suspense fallback={<UserInfoNavigatorSkeleton />}>
-            <UserInfoNavigator />
+            <UserInfoNavigator variant="large" />
             <div className="mt-9">
               <SignButtonGroup />
             </div>

--- a/app/__test__/ui/user/user-info-navigator.test.tsx
+++ b/app/__test__/ui/user/user-info-navigator.test.tsx
@@ -12,7 +12,7 @@ jest.mock('next/headers', () => ({
 
 describe('UserInfoNavigator', () => {
   it('UserInfoNavigator를 렌더링한다.', async () => {
-    render(await UserInfoNavigator());
+    render(await UserInfoNavigator({ variant: 'small' }));
 
     expect(await screen.findByText(/장진욱/i)).toBeInTheDocument();
     expect(await screen.findByText(/디지털콘텐츠디자인학과/i)).toBeInTheDocument();

--- a/app/ui/user/user-info-navigator/user-info-navigator.tsx
+++ b/app/ui/user/user-info-navigator/user-info-navigator.tsx
@@ -35,7 +35,7 @@ interface UserInfoNavigatorProps {
   variant?: 'small' | 'large';
 }
 
-export default async function UserInfoNavigator({ variant }: UserInfoNavigatorProps) {
+export default async function UserInfoNavigator({ variant = 'small' }: UserInfoNavigatorProps) {
   const userInfo = formatUserInfo(await auth());
 
   if (variant === 'large') {

--- a/app/ui/user/user-info-navigator/user-info-navigator.tsx
+++ b/app/ui/user/user-info-navigator/user-info-navigator.tsx
@@ -31,18 +31,38 @@ function formatUserInfo(userInfo: InitUserInfoResponse | UserInfoResponse | unde
   };
 }
 
-export default async function UserInfoNavigator() {
+interface UserInfoNavigatorProps {
+  variant?: 'small' | 'large';
+}
+
+export default async function UserInfoNavigator({ variant }: UserInfoNavigatorProps) {
   const userInfo = formatUserInfo(await auth());
 
+  if (variant === 'large') {
+    return (
+      <div className="flex flex-col items-center p-4 pb-6">
+        <Avatar className="w-24 h-24" alt="Profile picture" src="/assets/profile-image.png" />
+        <div className="flex flex-col items-center mt-5">
+          <div className="text-lg font-semibold">
+            {userInfo.name}
+            <span>님</span>
+          </div>
+          <div className="mb-3 text-sm truncate">{userInfo.major}</div>
+          <div className="text-sm text-gray-400">{userInfo.studentNumber}</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex items-center border-b-4 pb-6 space-x-4">
-      <Avatar className="w-16 h-16" alt="Profile picture" src={'/assets/profile-image.png'} />
+    <div className="flex flex-row items-center p-4 pb-6 border-b-4 space-x-4">
+      <Avatar className="w-16 h-16" alt="Profile picture" src="/assets/profile-image.png" />
       <div className="flex flex-col items-start">
-        <div>
-          <span className="font-semibold">{userInfo.name}</span>
+        <div className="text-md font-semibold">
+          {userInfo.name}
           <span>님</span>
         </div>
-        <div className="text-xs truncate">{userInfo.major}</div>
+        <div className="mb-2 text-xs truncate">{userInfo.major}</div>
         <div className="text-xs text-gray-400">{userInfo.studentNumber}</div>
       </div>
     </div>


### PR DESCRIPTION
## **📌** 작업 내용
close #225 

**[수정 전] => 반응형을 삭제해 마이페이지의 user-info-navigator가 첨부한 화면과 같이 렌더링됨**
<img width="1582" height="966" alt="스크린샷 2025-09-05 오후 4 18 27" src="https://github.com/user-attachments/assets/ab716aeb-ff5e-4fb5-96cf-80a050bc66eb" />

<br />

**[수정 후] => 저희가 이전에 예상했던 그대로 렌더링됩니다!**
<img width="1582" height="966" alt="스크린샷 2025-09-05 오후 4 17 06" src="https://github.com/user-attachments/assets/f1e2004e-b62d-44d8-8228-abf31113cf42" />
<img width="1056" height="966" alt="스크린샷 2025-09-05 오후 4 17 11" src="https://github.com/user-attachments/assets/d49f0a70-8799-401d-8b15-19e80433e145" />

> 구현 내용 및 작업 했던 내역

- [x] user-info-navigator의 style을 반응형 대신 variant를 props로 받아 크기를 조절해 사용할 수 있도록 구현
- [x] user-info-navigator jest 코드 수정 (props 추가)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - UserInfoNavigator에 variant 옵션(small/large) 추가. large는 세로 정렬, 큰 아바타, 상세 정보 스택으로 표시.
  - 기본값은 small이며 일부 화면에서 large 변형 사용.
- Style
  - small 변형의 레이아웃/타이포그래피 및 아바타 경로 정리로 시각적 일관성 향상.
- Refactor
  - UserInfoNavigator 사용 방식이 옵션 객체(variant) 전달 형태로 변경.
- Tests
  - 테스트를 variant 옵션 기반 호출로 업데이트하고 small 경로를 검증.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->