### PR TITLE
튜토리얼 페이지 이미지 깨짐 현상 해결

### DIFF
--- a/app/(sub-page)/tutorial/components/TutorialContent.tsx
+++ b/app/(sub-page)/tutorial/components/TutorialContent.tsx
@@ -15,7 +15,7 @@ function TutorialContent({ data }: TestContentProps) {
     <div className="flex flex-col lg:flex-row lg:items-center gap-6 p-6 rounded-2xl bg-gray-50">
       <div className="w-full lg:w-[60%] max-w-[520px] mx-auto lg:mx-0">
         <div className="relative w-full aspect-[16/10] rounded-2xl overflow-hidden shadow-lg">
-          <Image alt={item.alt} src={item.imageUrl} fill className="object-cover" />
+          <Image key={item.imageUrl.src} alt={item.alt} src={item.imageUrl} fill className="object-cover" unoptimized />
         </div>
       </div>
       <ul className="flex flex-col flex-1 gap-4 h-full justify-between">

--- a/app/(sub-page)/tutorial/components/TutorialContent.tsx
+++ b/app/(sub-page)/tutorial/components/TutorialContent.tsx
@@ -13,9 +13,9 @@ function TutorialContent({ data }: TestContentProps) {
 
   return (
     <div className="flex flex-col lg:flex-row lg:items-center gap-6 p-6 rounded-2xl bg-gray-50">
-      <div className="w-full lg:w-[70%] max-w-[650px] mx-auto lg:mx-0">
+      <div className="w-full lg:w-[60%] max-w-[520px] mx-auto lg:mx-0">
         <div className="relative w-full aspect-[16/10] rounded-2xl overflow-hidden shadow-lg">
-          <Image alt="tutorial-image" src={item.imageUrl} fill className="object-cover" />
+          <Image alt={item.alt} src={item.imageUrl} fill className="object-cover" />
         </div>
       </div>
       <ul className="flex flex-col flex-1 gap-4 h-full justify-between">

--- a/app/(sub-page)/tutorial/data.tsx
+++ b/app/(sub-page)/tutorial/data.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link';
 
 export interface TutorialItem {
   imageUrl: StaticImageData;
+  alt: string;
   icon?: StaticImageData;
   content: React.ReactNode;
 }
@@ -20,22 +21,27 @@ export interface TutorialItem {
 export const TUTORIAL_FEATRUE: TutorialItem[] = [
   {
     imageUrl: featureImage1,
+    alt: '강의 커스텀을 통해 졸업 사정을 예측',
     content: '강의 커스텀을 통한 졸업 사정 예측',
   },
   {
     imageUrl: featureImage2,
+    alt: '영역별 수강 현황 조회',
     content: '영역(공통교양 등)별 수강 현황 조회',
   },
   {
     imageUrl: featureImage3,
+    alt: '카테고리별 기이수 및 미이수 과목과 학점 조회',
     content: '카테고리별 기이수/미이수 과목 정보 및 학점 조회',
   },
   {
     imageUrl: featureImage4,
-    content: '학기 전·후 상태에 맞춘 시간표 생성/과목 추천',
+    alt: '학기 전후 상태에 맞춘 시간표 생성과 과목 추천',
+    content: '기이수/미이수 과목 필터링으로 시간표 구성 및 과목 추천',
   },
   {
     imageUrl: featureImage5,
+    alt: '학과 필수 과목과 인기 강의 탐색',
     content: '학과 필수 과목과 인기 강의 탐색',
   },
 ];
@@ -43,6 +49,7 @@ export const TUTORIAL_FEATRUE: TutorialItem[] = [
 export const TUTORIAL_UPLOAD: TutorialItem[] = [
   {
     imageUrl: uploadImage0,
+    alt: 'MyiWeb MSI 로그인',
     content: (
       <>
         <Link href="https://msi.mju.ac.kr/servlet/security/MySecurityStart" target="_blank">
@@ -54,18 +61,22 @@ export const TUTORIAL_UPLOAD: TutorialItem[] = [
   },
   {
     imageUrl: uploadImage1,
+    alt: '성적표 상담용 B4 메뉴 선택',
     content: '2. 좌측 성적/졸업 메뉴 → 성적표(상담용, B4)',
   },
   {
     imageUrl: uploadImage2,
+    alt: '성적표 조회 후 프린트 선택',
     content: '3. 우측 상단 조회버튼 → 프린트 아이콘',
   },
   {
     imageUrl: uploadImage3,
+    alt: 'PDF로 저장하도록 인쇄 대상 설정',
     content: '4. 인쇄 정보의 대상(PDF로 저장) 설정 → 하단 저장 버튼',
   },
   {
     imageUrl: uploadImage4,
+    alt: '저장한 성적표 파일 업로드',
     content: '5. 저장한 파일 업로드',
   },
 ];


### PR DESCRIPTION
## **📌** 작업 내용
close #282 

> 구현 내용 및 작업 했던 내역

- [x] 이미지 크기 수정 (크롬 기준으로 화면이 90%에 맞춰서 예쁘게(?) 보여서 100% 기준으로 괜찮게 보이도록 수정했습니다.)
- [x] 튜토리얼 데이터에 각각 alt를 추가해 Image에 `"tutorial-image"` 대신 각 이미지의 설명이 들어가도록 수정했습니다.
- [x] gif 이미지 깨짐 현상 개선을 위해 `TutorialContent` 컴포넌트의 내부 Image는 `unoptimized` 속성을 추가했습니다.

## 🤔 고민 했던 부분
튜토리얼 페이지이고, 해당 페이지에서는 이미지 수가 gif+png 합쳐서 총 8장이기 때문에 최적화하지 않아도 큰 영향을 미치지 않을 것이라 판단해 unoptimized 속성을 추가했습니다! 또한 next.js 문서에도 [애니메이션 이미지에는 unoptimized를 사용](https://nextjs-ko.org/docs/pages/api-reference/components/image#%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98-%EC%9D%B4%EB%AF%B8%EC%A7%80)하는 것을 권장하고 있는 것을 확인했습니다!

실제로 테스트는... 저는 정상이었어서,, 시도를 계속해서 해보겠지만 한 번 확인 부탁드리겠습니닷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 튜토리얼 이미지에 접근성 텍스트를 추가하여 화면 읽기 도구 호환성 개선

* **스타일**
  * 콘텐츠 최대 너비 조정으로 대화면 환경에서 레이아웃 및 가독성 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->