### PR TITLE
remove: 시간표 추천 버튼 제거 및 점검 모드 해제

### DIFF
--- a/app/(sub-page)/timetable/components/create-timetable/timetable-button-group.tsx
+++ b/app/(sub-page)/timetable/components/create-timetable/timetable-button-group.tsx
@@ -4,14 +4,12 @@ import Responsive from '@/app/ui/responsive';
 import SaveTimetableButton from './save-timetable-button';
 import ClearTimetableTrigger from './clear-timetable-trigger';
 import DeleteTimetableTrigger from './delete-timetable-trigger';
-import RecommendLectureTrigger from './recommend-lecture-trigger';
 import AddLectureTrigger from './add-lecture-trigger';
 
 function TimetableButtonGroup() {
   const LectureButtons = (
     <div className="flex gap-2">
       <AddLectureTrigger />
-      <RecommendLectureTrigger />
     </div>
   );
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,7 +38,7 @@ const allowedGuestPath = [
 
 const allowInitUserPath = ['/', '/tutorial', '/grade-upload', '/anonymous', '/anonymous/result', '/lecture-finder'];
 
-const MAINTENANCE_MODE = true;
+const MAINTENANCE_MODE = false;
 
 function isAllowedGuestPath(path: string, strict: boolean = false) {
   const allowedPath = strict ? allowedOnlyGuestPath : allowedGuestPath;


### PR DESCRIPTION
## **📌** 작업 내용

close #287

- [x] 시간표 페이지에서 추천 버튼 제거
- [x] 미들웨어 점검 모드 해제
- [x] 프로덕션 빌드 및 타입 검사

## 🤔 고민 했던 부분

- 추천 기능 내부 코드는 보존하고 진입 버튼만 제거해 추후 기능을 다시 노출할 수 있도록 했습니다.

## 검증

- `npm run build`
- `npm run type`
- `npm test` (커밋 훅에서 2회 실행, 2 suites / 3 tests 통과)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 시간표 생성 화면에서 강의 추천 버튼을 제거하고, 강의 추가 버튼만 표시합니다.
  * 유지보수 모드를 종료하여 인증 및 권한에 따른 정상적인 페이지 이동이 다시 활성화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->